### PR TITLE
do not choke when there's no victims

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -18,6 +18,9 @@ type Chaoskube struct {
 	Seed int64
 }
 
+// ErrPodNotFound is returned when no victim could be found
+var ErrPodNotFound = errors.New("pod not found")
+
 // New returns a new instance of Chaoskube. It expects a kubernetes client,
 // allows enabling dryRun mode and seeds the randomizer with the given seed.
 func New(client kubernetes.Interface, dryRun bool, seed int64) *Chaoskube {
@@ -51,7 +54,7 @@ func (c *Chaoskube) Victim() (v1.Pod, error) {
 	}
 
 	if len(pods) == 0 {
-		return v1.Pod{}, errors.New("pod not found")
+		return v1.Pod{}, ErrPodNotFound
 	}
 
 	index := rand.Intn(len(pods))

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -72,6 +72,15 @@ func TestAnotherVictim(t *testing.T) {
 	})
 }
 
+// TestNoVictimReturnsError tests that on missing victim it returns a known error
+func TestNoVictimReturnsError(t *testing.T) {
+	chaoskube := New(fake.NewSimpleClientset(), false, 2000)
+
+	if _, err := chaoskube.Victim(); err != ErrPodNotFound {
+		t.Errorf("expected %#v, got %#v", ErrPodNotFound, err)
+	}
+}
+
 // TestDeletePod tests deleting a particular pod
 func TestDeletePod(t *testing.T) {
 	chaoskube := setup(t, false, 0)

--- a/main.go
+++ b/main.go
@@ -83,20 +83,32 @@ func main() {
 	chaoskube := chaoskube.New(client, dryRun, time.Now().UTC().UnixNano())
 
 	for {
-		victim, err := chaoskube.Victim()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.Infof("Killing pod %s/%s", victim.Namespace, victim.Name)
-
-		if err := chaoskube.DeletePod(victim); err != nil {
+		if err := terminateVictim(chaoskube); err != nil {
 			log.Fatal(err)
 		}
 
 		log.Debugf("Sleeping for %s...", interval)
 		time.Sleep(interval)
 	}
+}
+
+func terminateVictim(ck *chaoskube.Chaoskube) error {
+	victim, err := ck.Victim()
+	if err == chaoskube.ErrPodNotFound {
+		log.Warnf("No victim could be found. If that's surprising double-check your label selector.")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Killing pod %s/%s", victim.Namespace, victim.Name)
+
+	if err := ck.DeletePod(victim); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func newClient() (*kubernetes.Clientset, error) {


### PR DESCRIPTION
if `Victim()` didn't find a pod it would crash the main loop for now reason. This becomes more relevant when additional filters (e.g. by labels or namespace) lead to an empty set of pods.

Note: `chaoskube` still fatals in the loop on any other error. This is probably undesireable in most cases but I prefer a fail-early approach at the moment to make any other possible errors more visible.