### PR TITLE
allow victim pods to be selected via label selector

### DIFF
--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -51,9 +51,9 @@ func TestCandidates(t *testing.T) {
 	})
 }
 
-// TestCandidatesWithLabelSelector tests that the list of pods available for
+// TestCandidatesLabelSelector tests that the list of pods available for
 // termination can be restricted by providing a label selector.
-func TestCandidatesWithLabelSelector(t *testing.T) {
+func TestCandidatesLabelSelector(t *testing.T) {
 	selector, err := labels.Parse("app=foo")
 	if err != nil {
 		t.Fatal(err)
@@ -68,6 +68,25 @@ func TestCandidatesWithLabelSelector(t *testing.T) {
 
 	validatePods(t, pods, []map[string]string{
 		{"namespace": "default", "name": "foo"},
+	})
+}
+
+// TestCandidatesExcludingLabelSelector tests that label selector supports exclusion
+func TestCandidatesExcludingLabelSelector(t *testing.T) {
+	selector, err := labels.Parse("app!=foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chaoskube := setup(t, selector, false, 0)
+
+	pods, err := chaoskube.Candidates()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validatePods(t, pods, []map[string]string{
+		{"namespace": "default", "name": "bar"},
 	})
 }
 
@@ -116,25 +135,6 @@ func TestAnotherVictimRespectsLabelSelector(t *testing.T) {
 
 	validatePod(t, victim, map[string]string{
 		"namespace": "default", "name": "foo",
-	})
-}
-
-// TestVictimRespectsLabelSelector tests that label selector supports exclusion
-func TestVictimRespectsLabelSelector(t *testing.T) {
-	selector, err := labels.Parse("app!=foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	chaoskube := setup(t, selector, false, 2000)
-
-	victim, err := chaoskube.Victim()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePod(t, victim, map[string]string{
-		"namespace": "default", "name": "bar",
 	})
 }
 

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -5,12 +5,15 @@ import (
 
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/labels"
 )
 
 // TestNew tests that arguments are passed to the new instance correctly
 func TestNew(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	chaoskube := New(client, false, 42)
+	selector := labels.SelectorFromSet(labels.Set{"foo": "bar"})
+
+	chaoskube := New(client, selector, false, 42)
 
 	if chaoskube == nil {
 		t.Errorf("expected Chaoskube but got nothing")
@@ -18,6 +21,10 @@ func TestNew(t *testing.T) {
 
 	if chaoskube.Client != client {
 		t.Errorf("expected %#v, got %#v", client, chaoskube.Client)
+	}
+
+	if chaoskube.Selector.String() != "foo=bar" {
+		t.Errorf("expected %s, got %s", "foo=bar", chaoskube.Selector.String())
 	}
 
 	if chaoskube.DryRun != false {
@@ -31,7 +38,7 @@ func TestNew(t *testing.T) {
 
 // TestCandidates tests the set of pods available for termination
 func TestCandidates(t *testing.T) {
-	chaoskube := setup(t, false, 0)
+	chaoskube := setup(t, labels.Everything(), false, 0)
 
 	pods, err := chaoskube.Candidates()
 	if err != nil {
@@ -44,9 +51,29 @@ func TestCandidates(t *testing.T) {
 	})
 }
 
+// TestCandidatesWithLabelSelector tests that the list of pods available for
+// termination can be restricted by providing a label selector.
+func TestCandidatesWithLabelSelector(t *testing.T) {
+	selector, err := labels.Parse("app=foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chaoskube := setup(t, selector, false, 0)
+
+	pods, err := chaoskube.Candidates()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validatePods(t, pods, []map[string]string{
+		{"namespace": "default", "name": "foo"},
+	})
+}
+
 // TestVictim tests that a pod is chosen from the candidates
 func TestVictim(t *testing.T) {
-	chaoskube := setup(t, false, 2000)
+	chaoskube := setup(t, labels.Everything(), false, 2000)
 
 	victim, err := chaoskube.Victim()
 	if err != nil {
@@ -60,7 +87,46 @@ func TestVictim(t *testing.T) {
 
 // TestAnotherVictim tests that the chosen victim is different for another seed
 func TestAnotherVictim(t *testing.T) {
-	chaoskube := setup(t, false, 4000)
+	chaoskube := setup(t, labels.Everything(), false, 4000)
+
+	victim, err := chaoskube.Victim()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validatePod(t, victim, map[string]string{
+		"namespace": "default", "name": "bar",
+	})
+}
+
+// TestAnotherVictimRespectsLabelSelector tests that a pod chosen from the
+// candidates respects the provided label selector
+func TestAnotherVictimRespectsLabelSelector(t *testing.T) {
+	selector, err := labels.Parse("app=foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chaoskube := setup(t, selector, false, 4000)
+
+	victim, err := chaoskube.Victim()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validatePod(t, victim, map[string]string{
+		"namespace": "default", "name": "foo",
+	})
+}
+
+// TestVictimRespectsLabelSelector tests that label selector supports exclusion
+func TestVictimRespectsLabelSelector(t *testing.T) {
+	selector, err := labels.Parse("app!=foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chaoskube := setup(t, selector, false, 2000)
 
 	victim, err := chaoskube.Victim()
 	if err != nil {
@@ -74,7 +140,7 @@ func TestAnotherVictim(t *testing.T) {
 
 // TestDeletePod tests deleting a particular pod
 func TestDeletePod(t *testing.T) {
-	chaoskube := setup(t, false, 0)
+	chaoskube := setup(t, labels.Everything(), false, 0)
 
 	victim := newPod("default", "foo")
 
@@ -94,7 +160,7 @@ func TestDeletePod(t *testing.T) {
 
 // TestDeletePodDryRun tests that enabled dry run doesn't delete the pod
 func TestDeletePodDryRun(t *testing.T) {
-	chaoskube := setup(t, true, 0)
+	chaoskube := setup(t, labels.Everything(), true, 0)
 
 	victim := newPod("default", "foo")
 
@@ -140,13 +206,16 @@ func newPod(namespace, name string) v1.Pod {
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
+			Labels: map[string]string{
+				"app": name,
+			},
 		},
 	}
 
 	return pod
 }
 
-func setup(t *testing.T, dryRun bool, seed int64) *Chaoskube {
+func setup(t *testing.T, selector labels.Selector, dryRun bool, seed int64) *Chaoskube {
 	pods := []v1.Pod{
 		newPod("default", "foo"),
 		newPod("default", "bar"),
@@ -160,5 +229,5 @@ func setup(t *testing.T, dryRun bool, seed int64) *Chaoskube {
 		}
 	}
 
-	return New(client, dryRun, seed)
+	return New(client, selector, dryRun, seed)
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -25,15 +26,17 @@ const (
 )
 
 var (
-	kubeconfig string
-	interval   time.Duration
-	inCluster  bool
-	deploy     bool
-	dryRun     bool
-	debug      bool
+	labelString string
+	kubeconfig  string
+	interval    time.Duration
+	inCluster   bool
+	deploy      bool
+	dryRun      bool
+	debug       bool
 )
 
 func init() {
+	kingpin.Flag("labels", "A set of labels that restricts the Pods available for termination").Default(labels.Everything().String()).StringVar(&labelString)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").Default(clientcmd.RecommendedHomeFile).StringVar(&kubeconfig)
 	kingpin.Flag("interval", "Interval between Pod terminations").Short('i').Default("10m").DurationVar(&interval)
 	kingpin.Flag("in-cluster", "If true, finds the Kubernetes cluster from the environment").Short('c').BoolVar(&inCluster)
@@ -80,7 +83,14 @@ func main() {
 		os.Exit(0)
 	}
 
-	chaoskube := chaoskube.New(client, dryRun, time.Now().UTC().UnixNano())
+	selector, err := labels.Parse(labelString)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Infof("Filtering pods by label selector: %s", selector.String())
+
+	chaoskube := chaoskube.New(client, selector, dryRun, time.Now().UTC().UnixNano())
 
 	for {
 		victim, err := chaoskube.Victim()


### PR DESCRIPTION
This allows passing a label selector via 

```
$ chaoskube --labels "foo=bar,baz!=qux"
INFO[0000] Filtering pods by label selector: baz!=qux,foo=bar
```

It will filter the pods available for termination by that label selector.

Note, that also exclusions are possible via `!=`. In fact, it supports `'=', '!=', '==', 'in', notin'`.


