### PR TITLE
allow filtering pods by namespace

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -16,7 +16,7 @@ type Chaoskube struct {
 	// a label selector which restricts the pods to choose from
 	Selector labels.Selector
 	// a namespace selector which restricts the pods to choose from
-	Namespace labels.Selector
+	Namespaces labels.Selector
 	// dry run will not allow any pod terminations
 	DryRun bool
 	// seed value for the randomizer
@@ -27,15 +27,15 @@ type Chaoskube struct {
 var ErrPodNotFound = errors.New("pod not found")
 
 // New returns a new instance of Chaoskube. It expects a kubernetes client, a
-// label selector and namespace to reduce the amount of affected pods as well as
+// label and namespace selector to reduce the amount of affected pods as well as
 // whether to enable dryRun mode and a seed to seed the randomizer with.
-func New(client kubernetes.Interface, selector labels.Selector, namespace labels.Selector, dryRun bool, seed int64) *Chaoskube {
+func New(client kubernetes.Interface, selector labels.Selector, namespaces labels.Selector, dryRun bool, seed int64) *Chaoskube {
 	c := &Chaoskube{
-		Client:    client,
-		Selector:  selector,
-		Namespace: namespace,
-		DryRun:    dryRun,
-		Seed:      seed,
+		Client:     client,
+		Selector:   selector,
+		Namespaces: namespaces,
+		DryRun:     dryRun,
+		Seed:       seed,
 	}
 
 	rand.Seed(c.Seed)
@@ -48,7 +48,7 @@ func New(client kubernetes.Interface, selector labels.Selector, namespace labels
 func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	listOptions := v1.ListOptions{LabelSelector: c.Selector.String()}
 
-	podList, err := c.Client.Core().Pods(c.Namespace.String()).List(listOptions)
+	podList, err := c.Client.Core().Pods(c.Namespaces.String()).List(listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -2,11 +2,13 @@ package chaoskube
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/labels"
+	"k8s.io/client-go/pkg/selection"
 )
 
 // Chaoskube represents an instance of chaoskube
@@ -14,7 +16,7 @@ type Chaoskube struct {
 	// a kubernetes client object
 	Client kubernetes.Interface
 	// a label selector which restricts the pods to choose from
-	Selector labels.Selector
+	Labels labels.Selector
 	// a namespace selector which restricts the pods to choose from
 	Namespaces labels.Selector
 	// dry run will not allow any pod terminations
@@ -29,10 +31,10 @@ var ErrPodNotFound = errors.New("pod not found")
 // New returns a new instance of Chaoskube. It expects a kubernetes client, a
 // label and namespace selector to reduce the amount of affected pods as well as
 // whether to enable dryRun mode and a seed to seed the randomizer with.
-func New(client kubernetes.Interface, selector labels.Selector, namespaces labels.Selector, dryRun bool, seed int64) *Chaoskube {
+func New(client kubernetes.Interface, labels labels.Selector, namespaces labels.Selector, dryRun bool, seed int64) *Chaoskube {
 	c := &Chaoskube{
 		Client:     client,
-		Selector:   selector,
+		Labels:     labels,
 		Namespaces: namespaces,
 		DryRun:     dryRun,
 		Seed:       seed,
@@ -44,16 +46,21 @@ func New(client kubernetes.Interface, selector labels.Selector, namespaces label
 }
 
 // Candidates returns the list of pods that are available for termination.
-// It returns all pods in all namespaces matching the label selector.
+// It returns all pods matching the label selector and at least one namespace.
 func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
-	listOptions := v1.ListOptions{LabelSelector: c.Selector.String()}
+	listOptions := v1.ListOptions{LabelSelector: c.Labels.String()}
 
-	podList, err := c.Client.Core().Pods(c.Namespaces.String()).List(listOptions)
+	podList, err := c.Client.Core().Pods(v1.NamespaceAll).List(listOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	return podList.Items, nil
+	pods, err := filterPodsByNamespaceSelector(podList.Items, c.Namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return pods, nil
 }
 
 // Victim returns a random pod from the list of Candidates.
@@ -79,4 +86,60 @@ func (c *Chaoskube) DeletePod(victim v1.Pod) error {
 	}
 
 	return c.Client.Core().Pods(victim.Namespace).Delete(victim.Name, nil)
+}
+
+// filterPodsByNamespaceSelector filters a list of pods by a given namespace selector.
+func filterPodsByNamespaceSelector(pods []v1.Pod, namespaces labels.Selector) ([]v1.Pod, error) {
+	// empty filter returns original list
+	if namespaces.Empty() {
+		return pods, nil
+	}
+
+	filteredList := []v1.Pod{}
+
+	// split requirements into including and excluding groups
+	reqs, _ := namespaces.Requirements()
+	reqIncl := []labels.Requirement{}
+	reqExcl := []labels.Requirement{}
+
+	for _, req := range reqs {
+		switch req.Operator() {
+		case selection.Exists:
+			reqIncl = append(reqIncl, req)
+		case selection.DoesNotExist:
+			reqExcl = append(reqExcl, req)
+		default:
+			return filteredList, fmt.Errorf("unsupported operator: %s", req.Operator())
+		}
+	}
+
+	for _, pod := range pods {
+		// if there aren't any including requirements, we're in by default
+		included := len(reqIncl) == 0
+
+		// convert the pod's namespace to an equivalent label selector
+		nsSelector := labels.Set{pod.Namespace: ""}
+
+		// include pod if one including requirement matches
+		for _, req := range reqIncl {
+			if req.Matches(nsSelector) {
+				included = true
+				break
+			}
+		}
+
+		// exclude pod if it is filtered out by at least one excluding requirement
+		for _, req := range reqExcl {
+			if !req.Matches(nsSelector) {
+				included = false
+				break
+			}
+		}
+
+		if included {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList, nil
 }

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -15,8 +15,8 @@ type Chaoskube struct {
 	Client kubernetes.Interface
 	// a label selector which restricts the pods to choose from
 	Selector labels.Selector
-	// a namespace which restricts the pods to choose from
-	Namespace string
+	// a namespace selector which restricts the pods to choose from
+	Namespace labels.Selector
 	// dry run will not allow any pod terminations
 	DryRun bool
 	// seed value for the randomizer
@@ -29,7 +29,7 @@ var ErrPodNotFound = errors.New("pod not found")
 // New returns a new instance of Chaoskube. It expects a kubernetes client, a
 // label selector and namespace to reduce the amount of affected pods as well as
 // whether to enable dryRun mode and a seed to seed the randomizer with.
-func New(client kubernetes.Interface, selector labels.Selector, namespace string, dryRun bool, seed int64) *Chaoskube {
+func New(client kubernetes.Interface, selector labels.Selector, namespace labels.Selector, dryRun bool, seed int64) *Chaoskube {
 	c := &Chaoskube{
 		Client:    client,
 		Selector:  selector,
@@ -48,7 +48,7 @@ func New(client kubernetes.Interface, selector labels.Selector, namespace string
 func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	listOptions := v1.ListOptions{LabelSelector: c.Selector.String()}
 
-	podList, err := c.Client.Core().Pods(c.Namespace).List(listOptions)
+	podList, err := c.Client.Core().Pods(c.Namespace.String()).List(listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -44,12 +44,7 @@ func TestNew(t *testing.T) {
 func TestCandidates(t *testing.T) {
 	chaoskube := setup(t, labels.Everything(), v1.NamespaceAll, false, 0)
 
-	pods, err := chaoskube.Candidates()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePods(t, pods, []map[string]string{
+	validateCandidates(t, chaoskube, []map[string]string{
 		{"namespace": "default", "name": "foo"},
 		{"namespace": "testing", "name": "bar"},
 	})
@@ -65,12 +60,7 @@ func TestCandidatesLabelSelector(t *testing.T) {
 
 	chaoskube := setup(t, selector, v1.NamespaceAll, false, 0)
 
-	pods, err := chaoskube.Candidates()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePods(t, pods, []map[string]string{
+	validateCandidates(t, chaoskube, []map[string]string{
 		{"namespace": "default", "name": "foo"},
 	})
 }
@@ -84,12 +74,7 @@ func TestCandidatesExcludingLabelSelector(t *testing.T) {
 
 	chaoskube := setup(t, selector, v1.NamespaceAll, false, 0)
 
-	pods, err := chaoskube.Candidates()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePods(t, pods, []map[string]string{
+	validateCandidates(t, chaoskube, []map[string]string{
 		{"namespace": "testing", "name": "bar"},
 	})
 }
@@ -99,12 +84,7 @@ func TestCandidatesExcludingLabelSelector(t *testing.T) {
 func TestCandidatesNamespace(t *testing.T) {
 	chaoskube := setup(t, labels.Everything(), "default", false, 0)
 
-	pods, err := chaoskube.Candidates()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePods(t, pods, []map[string]string{
+	validateCandidates(t, chaoskube, []map[string]string{
 		{"namespace": "default", "name": "foo"},
 	})
 }
@@ -113,12 +93,7 @@ func TestCandidatesNamespace(t *testing.T) {
 func TestVictim(t *testing.T) {
 	chaoskube := setup(t, labels.Everything(), v1.NamespaceAll, false, 2000)
 
-	victim, err := chaoskube.Victim()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePod(t, victim, map[string]string{
+	validateVictim(t, chaoskube, map[string]string{
 		"namespace": "default", "name": "foo",
 	})
 }
@@ -127,12 +102,7 @@ func TestVictim(t *testing.T) {
 func TestAnotherVictim(t *testing.T) {
 	chaoskube := setup(t, labels.Everything(), v1.NamespaceAll, false, 4000)
 
-	victim, err := chaoskube.Victim()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePod(t, victim, map[string]string{
+	validateVictim(t, chaoskube, map[string]string{
 		"namespace": "testing", "name": "bar",
 	})
 }
@@ -147,12 +117,7 @@ func TestAnotherVictimRespectsLabelSelector(t *testing.T) {
 
 	chaoskube := setup(t, selector, v1.NamespaceAll, false, 4000)
 
-	victim, err := chaoskube.Victim()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePod(t, victim, map[string]string{
+	validateVictim(t, chaoskube, map[string]string{
 		"namespace": "default", "name": "foo",
 	})
 }
@@ -176,12 +141,7 @@ func TestDeletePod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pods, err := chaoskube.Candidates()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePods(t, pods, []map[string]string{
+	validateCandidates(t, chaoskube, []map[string]string{
 		{"namespace": "testing", "name": "bar"},
 	})
 }
@@ -196,18 +156,31 @@ func TestDeletePodDryRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pods, err := chaoskube.Candidates()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	validatePods(t, pods, []map[string]string{
+	validateCandidates(t, chaoskube, []map[string]string{
 		{"namespace": "default", "name": "foo"},
 		{"namespace": "testing", "name": "bar"},
 	})
 }
 
 // helper functions
+
+func validateCandidates(t *testing.T, chaoskube *Chaoskube, expected []map[string]string) {
+	pods, err := chaoskube.Candidates()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validatePods(t, pods, expected)
+}
+
+func validateVictim(t *testing.T, chaoskube *Chaoskube, expected map[string]string) {
+	victim, err := chaoskube.Victim()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validatePod(t, victim, expected)
+}
 
 func validatePods(t *testing.T, pods []v1.Pod, expected []map[string]string) {
 	if len(pods) != len(expected) {

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -12,9 +12,9 @@ import (
 func TestNew(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	selector, _ := labels.Parse("foo=bar")
-	namespace, _ := labels.Parse("qux")
+	namespaces, _ := labels.Parse("qux")
 
-	chaoskube := New(client, selector, namespace, false, 42)
+	chaoskube := New(client, selector, namespaces, false, 42)
 
 	if chaoskube == nil {
 		t.Errorf("expected Chaoskube but got nothing")
@@ -28,8 +28,8 @@ func TestNew(t *testing.T) {
 		t.Errorf("expected %s, got %s", "foo=bar", chaoskube.Selector.String())
 	}
 
-	if chaoskube.Namespace.String() != "qux" {
-		t.Errorf("expected %s, got %s", "qux", chaoskube.Namespace.String())
+	if chaoskube.Namespaces.String() != "qux" {
+		t.Errorf("expected %s, got %s", "qux", chaoskube.Namespaces.String())
 	}
 
 	if chaoskube.DryRun != false {
@@ -80,12 +80,12 @@ func TestCandidatesExcludingLabelSelector(t *testing.T) {
 	})
 }
 
-// TestCandidatesNamespace tests that the list of pods available for
-// termination can be restricted by a namespace.
-func TestCandidatesNamespace(t *testing.T) {
-	namespace, _ := labels.Parse("default")
+// TestCandidatesNamespaces tests that the list of pods available for
+// termination can be restricted by namespaces.
+func TestCandidatesNamespaces(t *testing.T) {
+	namespaces, _ := labels.Parse("default")
 
-	chaoskube := setup(t, labels.Everything(), namespace, false, 0)
+	chaoskube := setup(t, labels.Everything(), namespaces, false, 0)
 
 	validateCandidates(t, chaoskube, []map[string]string{
 		{"namespace": "default", "name": "foo"},
@@ -219,7 +219,7 @@ func newPod(namespace, name string) v1.Pod {
 	return pod
 }
 
-func setup(t *testing.T, selector labels.Selector, namespace labels.Selector, dryRun bool, seed int64) *Chaoskube {
+func setup(t *testing.T, selector labels.Selector, namespaces labels.Selector, dryRun bool, seed int64) *Chaoskube {
 	pods := []v1.Pod{
 		newPod("default", "foo"),
 		newPod("testing", "bar"),
@@ -233,5 +233,5 @@ func setup(t *testing.T, selector labels.Selector, namespace labels.Selector, dr
 		}
 	}
 
-	return New(client, selector, namespace, dryRun, seed)
+	return New(client, selector, namespaces, dryRun, seed)
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ const (
 
 var (
 	labelString string
+	namespace   string
 	kubeconfig  string
 	interval    time.Duration
 	inCluster   bool
@@ -36,7 +37,8 @@ var (
 )
 
 func init() {
-	kingpin.Flag("labels", "A set of labels that restricts the Pods available for termination").Default(labels.Everything().String()).StringVar(&labelString)
+	kingpin.Flag("labels", "A set of labels to restrict the list of affected pods. Defaults to everything.").Default(labels.Everything().String()).StringVar(&labelString)
+	kingpin.Flag("namespace", "The namespace affected pods have to be in. Defaults to everything.").Default(v1.NamespaceAll).StringVar(&namespace)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").Default(clientcmd.RecommendedHomeFile).StringVar(&kubeconfig)
 	kingpin.Flag("interval", "Interval between Pod terminations").Short('i').Default("10m").DurationVar(&interval)
 	kingpin.Flag("in-cluster", "If true, finds the Kubernetes cluster from the environment").Short('c').BoolVar(&inCluster)
@@ -88,9 +90,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Infof("Filtering pods by label selector: %s", selector.String())
+	if !selector.Empty() {
+		log.Infof("Filtering pods by label selector: %s", selector.String())
+	}
 
-	chaoskube := chaoskube.New(client, selector, dryRun, time.Now().UTC().UnixNano())
+	if namespace != v1.NamespaceAll {
+		log.Infof("Filtering pods by namespace: %s", namespace)
+	}
+
+	chaoskube := chaoskube.New(client, selector, namespace, dryRun, time.Now().UTC().UnixNano())
 
 	for {
 		if err := terminateVictim(chaoskube); err != nil {
@@ -105,7 +113,7 @@ func main() {
 func terminateVictim(ck *chaoskube.Chaoskube) error {
 	victim, err := ck.Victim()
 	if err == chaoskube.ErrPodNotFound {
-		log.Warnf("No victim could be found. If that's surprising double-check your label selector.")
+		log.Warnf("No victim could be found. If that's surprising double-check your label selector and namespace filter.")
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
This allows filtering pods by arbitrary namespaces.

```
$ ./chaoskube --namespaces default,testing,staging
...
INFO[0000] Filtering pods by namespaces: default,staging,testing
```

This will filter for pods in the three namespaces default, staging and testing, not more.

It can be negated and combined with the label selector:

```
$ ./chaoskube --labels '!run,foo,app=mate' --namespaces '!kube-system,!production'
...
INFO[0000] Filtering pods by label selector: app=mate,foo,!run
INFO[0000] Filtering pods by namespaces: !kube-system,!production
```

This will select all pods that are not in the `kube-system` or `production` namespaces and have the label `app` with the value of `mate`, the label `foo` with any value and no `run` label with any value set.