### PR TITLE
retire support for go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 
 go:
 - 1.8
-- 1.9
+- 1.9beta2
 - tip
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ os:
 language: go
 
 go:
-- 1.7
 - 1.8
+- 1.9
 - tip
 
 before_install:


### PR DESCRIPTION
supporting the two most recent minor versions and now switching to go.19 and go1.8.