### PR TITLE
Minify the kube

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM golang:1.9-alpine
-
-COPY . /go/src/github.com/linki/chaoskube
-RUN go install -v github.com/linki/chaoskube
-RUN addgroup -S chaoskube && adduser -S -g chaoskube chaoskube
-
-USER chaoskube
-ENTRYPOINT ["/go/bin/chaoskube"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,8 @@
+FROM golang:1.9-alpine
+
+RUN addgroup -S chaoskube && adduser -S -g chaoskube chaoskube \
+ && apk add --no-cache git \
+ && CGO_ENABLED=0 go get github.com/linki/chaoskube
+
+USER chaoskube
+ENTRYPOINT ["/go/bin/chaoskube"]

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,0 +1,4 @@
+FROM scratch
+COPY ./chaoskube /chaoskube
+
+ENTRYPOINT ["/chaoskube"]

--- a/nanokube
+++ b/nanokube
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker build -t chaoskube-build -f ./Dockerfile.build .
+id=$(docker create chaoskube-build)
+docker cp $id:/go/bin/chaoskube ./chaoskube
+chmod 755 ./chaoskube
+docker build -t chaoskube-deploy  -f ./Dockerfile.deploy .
+rm ./chaoskube


### PR DESCRIPTION
This is how I addressed: https://github.com/linki/chaoskube/issues/22

The idea is to first create a golang-alpine container and install the binary inside, then create a second container from scratch and copy the binary over and set the entry point to it.
This reduces the image size quite a bit:

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
chaoskube-deploy    latest              4ca2107465ff        6 minutes ago       41.6MB
chaoskube-build     latest              bde4d9a67d57        6 minutes ago       480MB
```

Hope this helps :)

Feel free to adapt this!