### PR TITLE
Add percentage functionality

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -79,6 +79,15 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	return pods, nil
 }
 
+// Returns the number of deletable candidates
+func (c *Chaoskube) NumberOfCandidates() (int, error) {
+	pods, err := c.Candidates()
+	if err != nil {
+		return -1, err
+	}
+	return len(pods), nil
+}
+
 // Victim returns a random pod from the list of Candidates.
 func (c *Chaoskube) Victim() (v1.Pod, error) {
 	pods, err := c.Candidates()

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	deploy      bool
 	dryRun      bool
 	debug       bool
+	percentage  int
 )
 
 func init() {
@@ -42,16 +43,21 @@ func init() {
 	kingpin.Flag("annotations", "A set of annotations to restrict the list of affected pods. Defaults to everything.").Default(labels.Everything().String()).StringVar(&annString)
 	kingpin.Flag("namespaces", "A set of namespaces to restrict the list of affected pods. Defaults to everything.").Default(v1.NamespaceAll).StringVar(&nsString)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").Default(clientcmd.RecommendedHomeFile).StringVar(&kubeconfig)
-	kingpin.Flag("interval", "Interval between Pod terminations").Short('i').Default("10m").DurationVar(&interval)
+	kingpin.Flag("interval", "Interval between Pod terminations").Short('i').DurationVar(&interval)
 	kingpin.Flag("in-cluster", "If true, finds the Kubernetes cluster from the environment").Short('c').BoolVar(&inCluster)
 	kingpin.Flag("deploy", "If true, deploys chaoskube in the current cluster with the provided configuration").Short('d').BoolVar(&deploy)
 	kingpin.Flag("dry-run", "If true, don't actually do anything.").Default("true").BoolVar(&dryRun)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&debug)
+	kingpin.Flag("percentage", "Percentage of pods to be terminated per hour").Short('p').IntVar(&percentage)
 }
 
 func main() {
 	kingpin.Version(version)
 	kingpin.Parse()
+
+	if (interval.Nanoseconds() != 0 && percentage != 0) || (interval.Nanoseconds() == 0 && percentage == 0) {
+		log.Fatal("Needs exactly one of 'interval' or 'percentage' to be set.")
+	}
 
 	if debug {
 		log.SetLevel(log.DebugLevel)
@@ -115,15 +121,40 @@ func main() {
 	}
 
 	chaoskube := chaoskube.New(client, labelSelector, annotations, namespaces, log.StandardLogger(), dryRun, time.Now().UTC().UnixNano())
-
+	ticker := updatedTicker(chaoskube, percentage)
 	for {
-		if err := chaoskube.TerminateVictim(); err != nil {
-			log.Fatal(err)
+		select {
+		case <-ticker.C:
+			ticker.Stop()
+			if err := chaoskube.TerminateVictim(); err != nil {
+				log.Fatal(err)
+			}
+			ticker = updatedTicker(chaoskube, percentage)
 		}
-
-		log.Debugf("Sleeping for %s...", interval)
-		time.Sleep(interval)
 	}
+}
+
+func updatedTicker(chaoskube *chaoskube.Chaoskube, percentage int) *time.Ticker {
+	oldInterval := interval
+	if interval.Nanoseconds() == 0 {
+		interval = calculateInterval(chaoskube, percentage)
+	}
+	if interval < 1 {
+		interval = 0
+	}
+	ticker := time.NewTicker(interval)
+	if interval != oldInterval {
+		log.Infof("Changing interval to: %s", interval)
+	}
+	return ticker
+}
+
+func calculateInterval(chaoskube *chaoskube.Chaoskube, percentage int) time.Duration {
+	num, err := chaoskube.NumberOfCandidates()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return (time.Millisecond * (time.Duration(int((3600000.0 / float32(num)) * (100.0 / float32(percentage))))))
 }
 
 func newClient() (*kubernetes.Clientset, error) {


### PR DESCRIPTION
This is my idea for: https://github.com/linki/chaoskube/issues/20

Changes:
- `chaoskube` now supports the `--percentage` flag
- `--percentage` takes an integer as option
- when using e.g. `--percentage 10` ten percent of the current pods will be killed. `chaoskube` checks after every pod termination how many candidates there are and then calculates how long it will have to wait until it has to terminate another pod so that it reaches `x` percent per hour. This will handle more services getting deploy or old ones removed without having to restart `chaoskube` 
- `chaoskube` needs to be invoked with either `--interval` or `--percentage`, there is no default anymore

Let me know what you think.

I removed `log.Debugf("Sleeping for %s...", interval)` because we are technically not sleeping anymore. And I only inform about interval updates. Feel free to ask me to bring that functionality back if you want it to stay.