### PR TITLE
build using docker's multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
-FROM golang:1.9-alpine
+# builder image
+FROM golang:1.9-alpine as builder
 
-COPY . /go/src/github.com/linki/chaoskube
-RUN go install -v github.com/linki/chaoskube
+WORKDIR /go/src/github.com/linki/chaoskube
+COPY . .
+RUN go test -v ./chaoskube ./util
+RUN go install -v -ldflags "-w -s"
+
+# final image
+FROM alpine:3.6
+MAINTAINER Linki <linki+docker.com@posteo.de>
+
 RUN addgroup -S chaoskube && adduser -S -g chaoskube chaoskube
+COPY --from=builder /go/bin/chaoskube /go/bin/chaoskube
 
 USER chaoskube
 ENTRYPOINT ["/go/bin/chaoskube"]


### PR DESCRIPTION
Build using a single Dockerfile and also leads to a much smaller image. Also fixes https://github.com/linki/chaoskube/issues/36.