### PR TITLE
chore: drop go v1.8 from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ os:
 language: go
 
 go:
-- 1.8
-- 1.9beta2
+- 1.9
 - tip
 
 before_install:


### PR DESCRIPTION
Retire support for Go 1.8