### PR TITLE
Use in-cluster config in example deployment

### DIFF
--- a/examples/chaoskube.yaml
+++ b/examples/chaoskube.yaml
@@ -16,6 +16,8 @@ spec:
       - name: chaoskube
         image: quay.io/linki/chaoskube:v0.5.0
         args:
+        # use in-cluster configuration
+        - --in-cluster
         # kill a pod every 10 minutes
         - --interval=10m
         # only target pods in the test environment


### PR DESCRIPTION
Otherwise, you'll get `level=fatal msg="stat /root/.kube/config: no such file or directory"`