### PR TITLE
Allow to suspend chaoskube at certain weekdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ spec:
       ...
 ```
 
+## Limiting the Chaos
+
+You can limit the time when chaos is introduced. To turn on this feature, add a comma-separated list of abbreviated weekdays via the `--excluded-weekdays` option and specify a `--timezone` in which to interpret those weekdays. Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). If you're testing `chaoskube` from your local machine then `Local` makes the most sense. Once you deploy `chaoskube` to your cluster you should deploy it with a specific timezone, e.g. where most of your team members are living, so that both your team and `chaoskube` have a common understanding when a particular weekday begins and ends. If your team is spread across multiple time zones it's probably best to pick `UTC` which is also the default. Picking the wrong timezone shifts the meaning of, e.g., Saturday by a couple of hours between you and the server.
+
+## Flags
+
+| Option                | Description                                                          | Default                |
+|-----------------------|----------------------------------------------------------------------|------------------------|
+| `--interval`          | interval between pod terminations                                    | 10m                    |
+| `--labels`            | label selector to filter pods by                                     | (matches everything)   |
+| `--annotations`       | annotation selector to filter pods by                                | (matches everything)   |
+| `--namespaces`        | namespace selector to filter pods by                                 | (all namespaces)       |
+| `--excluded-weekdays` | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)  |
+| `--timezone`          | timezone from tz database, e.g. "America/New_York", "UTC" or "Local" | (UTC)                  |
+| `--dry-run`           | don't kill pods, only log what would have been done                  | true                   |
+
 ## Contributing
 
 Feel free to create issues or submit pull requests.

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -49,8 +49,10 @@ var msgVictimNotFound = "No victim could be found. If that's surprising double-c
 var msgWeekdayExcluded = "This day of the week is excluded from chaos."
 
 // New returns a new instance of Chaoskube. It expects a kubernetes client, a
-// label and namespace selector to reduce the amount of affected pods as well as
-// whether to enable dryRun mode and a seed to seed the randomizer with.
+// label, annotation and/or namespace selector to reduce the amount of affected
+// pods as well as whether to enable dryRun mode and a seed to seed the randomizer
+// with. You can also provide a list of weekdays and corresponding time zone when
+// chaoskube should be inactive.
 func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, timezone *time.Location, logger log.StdLogger, dryRun bool, seed int64) *Chaoskube {
 	c := &Chaoskube{
 		Client:           client,

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -24,12 +25,16 @@ type Chaoskube struct {
 	Annotations labels.Selector
 	// a namespace selector which restricts the pods to choose from
 	Namespaces labels.Selector
+	// a list of weekdays when termination is suspended
+	ExcludedWeekdays []time.Weekday
 	// an instance of logrus.StdLogger to write log messages to
 	Logger log.StdLogger
 	// dry run will not allow any pod terminations
 	DryRun bool
 	// seed value for the randomizer
 	Seed int64
+	// a function to retrieve the current time
+	Now func() time.Time
 }
 
 // ErrPodNotFound is returned when no victim could be found
@@ -38,18 +43,23 @@ var ErrPodNotFound = errors.New("pod not found")
 // msgVictimNotFound is the log message when no victim was found
 var msgVictimNotFound = "No victim could be found. If that's surprising double-check your selectors."
 
+// msgWeekdayExcluded is the log message when termination is suspended due to the weekday filter
+var msgWeekdayExcluded = "This day of the week is excluded from chaos."
+
 // New returns a new instance of Chaoskube. It expects a kubernetes client, a
 // label and namespace selector to reduce the amount of affected pods as well as
 // whether to enable dryRun mode and a seed to seed the randomizer with.
-func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, logger log.StdLogger, dryRun bool, seed int64) *Chaoskube {
+func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, logger log.StdLogger, dryRun bool, seed int64) *Chaoskube {
 	c := &Chaoskube{
-		Client:      client,
-		Labels:      labels,
-		Annotations: annotations,
-		Namespaces:  namespaces,
-		Logger:      logger,
-		DryRun:      dryRun,
-		Seed:        seed,
+		Client:           client,
+		Labels:           labels,
+		Annotations:      annotations,
+		Namespaces:       namespaces,
+		ExcludedWeekdays: excludedWeekdays,
+		Logger:           logger,
+		DryRun:           dryRun,
+		Seed:             seed,
+		Now:              time.Now,
 	}
 
 	rand.Seed(c.Seed)
@@ -109,6 +119,13 @@ func (c *Chaoskube) DeletePod(victim v1.Pod) error {
 
 // TerminateVictim picks and deletes a victim if found.
 func (c *Chaoskube) TerminateVictim() error {
+	for _, wd := range c.ExcludedWeekdays {
+		if wd == c.Now().Weekday() {
+			c.Logger.Printf(msgWeekdayExcluded)
+			return nil
+		}
+	}
+
 	victim, err := c.Victim()
 	if err == ErrPodNotFound {
 		c.Logger.Printf(msgVictimNotFound)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func init() {
 	kingpin.Flag("annotations", "A set of annotations to restrict the list of affected pods. Defaults to everything.").StringVar(&annString)
 	kingpin.Flag("namespaces", "A set of namespaces to restrict the list of affected pods. Defaults to everything.").StringVar(&nsString)
 	kingpin.Flag("excluded-weekdays", "A list of weekdays when termination is suspended, e.g. sat,sun").StringVar(&excludedWeekdays)
-	kingpin.Flag("timezone", "The timezone to apply when detecting the current weekday, e.g. Local, UTC, Europe/Berlin. Defaults to Local.").Default(time.Local.String()).StringVar(&timezone)
+	kingpin.Flag("timezone", "The timezone to apply when detecting the current weekday, e.g. UTC, Local, Europe/Berlin. Defaults to UTC.").Default("UTC").StringVar(&timezone)
 	kingpin.Flag("master", "The address of the Kubernetes cluster to target").StringVar(&master)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").StringVar(&kubeconfig)
 	kingpin.Flag("interval", "Interval between Pod terminations").Default("10m").DurationVar(&interval)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var (
 	annString        string
 	nsString         string
 	excludedWeekdays string
+	timezone         string
 	master           string
 	kubeconfig       string
 	interval         time.Duration
@@ -35,6 +36,7 @@ func init() {
 	kingpin.Flag("annotations", "A set of annotations to restrict the list of affected pods. Defaults to everything.").StringVar(&annString)
 	kingpin.Flag("namespaces", "A set of namespaces to restrict the list of affected pods. Defaults to everything.").StringVar(&nsString)
 	kingpin.Flag("excluded-weekdays", "A list of weekdays when termination is suspended, e.g. sat,sun").StringVar(&excludedWeekdays)
+	kingpin.Flag("timezone", "The timezone to apply when detecting the current weekday, e.g. Local, UTC, Europe/Berlin. Defaults to Local.").Default(time.Local.String()).StringVar(&timezone)
 	kingpin.Flag("master", "The address of the Kubernetes cluster to target").StringVar(&master)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").StringVar(&kubeconfig)
 	kingpin.Flag("interval", "Interval between Pod terminations").Default("10m").DurationVar(&interval)
@@ -86,6 +88,13 @@ func main() {
 		log.Infof("Filtering pods by namespaces: %s", namespaces.String())
 	}
 
+	parsedTimezone, err := time.LoadLocation(timezone)
+	if err != nil {
+		log.Fatal(err)
+	}
+	timezoneName, _ := time.Now().In(parsedTimezone).Zone()
+	log.Infof("Using time zone: %s (%s)", parsedTimezone.String(), timezoneName)
+
 	parsedWeekdays := parseWeekdays(excludedWeekdays)
 	if len(parsedWeekdays) > 0 {
 		log.Infof("Excluding weekdays: %s", parsedWeekdays)
@@ -97,6 +106,7 @@ func main() {
 		annotations,
 		namespaces,
 		parsedWeekdays,
+		parsedTimezone,
 		log.StandardLogger(),
 		dryRun,
 		time.Now().UTC().UnixNano(),

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -14,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/linki/chaoskube/chaoskube"
+	"github.com/linki/chaoskube/util"
 )
 
 var (
@@ -95,7 +95,7 @@ func main() {
 	timezoneName, _ := time.Now().In(parsedTimezone).Zone()
 	log.Infof("Using time zone: %s (%s)", parsedTimezone.String(), timezoneName)
 
-	parsedWeekdays := parseWeekdays(excludedWeekdays)
+	parsedWeekdays := util.ParseWeekdays(excludedWeekdays)
 	if len(parsedWeekdays) > 0 {
 		log.Infof("Excluding weekdays: %s", parsedWeekdays)
 	}
@@ -120,26 +120,6 @@ func main() {
 		log.Debugf("Sleeping for %s...", interval)
 		time.Sleep(interval)
 	}
-}
-
-func parseWeekdays(weekdays string) []time.Weekday {
-	var days = map[string]time.Weekday{
-		"sun": time.Sunday,
-		"mon": time.Monday,
-		"tue": time.Tuesday,
-		"wed": time.Wednesday,
-		"thu": time.Thursday,
-		"fri": time.Friday,
-		"sat": time.Saturday,
-	}
-
-	parsedWeekdays := []time.Weekday{}
-	for _, wd := range strings.Split(weekdays, ",") {
-		if day, ok := days[strings.TrimSpace(strings.ToLower(wd))]; ok {
-			parsedWeekdays = append(parsedWeekdays, day)
-		}
-	}
-	return parsedWeekdays
 }
 
 func newClient() (*kubernetes.Clientset, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"strings"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
@@ -19,4 +22,26 @@ func NewPod(namespace, name string) v1.Pod {
 			},
 		},
 	}
+}
+
+// ParseWeekdays takes a comma-separated list of abbreviated weekdays (e.g. sat,sun) and turns them
+// into a slice of time.Weekday. It ignores any whitespace and any invalid weekdays.
+func ParseWeekdays(weekdays string) []time.Weekday {
+	var days = map[string]time.Weekday{
+		"sun": time.Sunday,
+		"mon": time.Monday,
+		"tue": time.Tuesday,
+		"wed": time.Wednesday,
+		"thu": time.Thursday,
+		"fri": time.Friday,
+		"sat": time.Saturday,
+	}
+
+	parsedWeekdays := []time.Weekday{}
+	for _, wd := range strings.Split(weekdays, ",") {
+		if day, ok := days[strings.TrimSpace(strings.ToLower(wd))]; ok {
+			parsedWeekdays = append(parsedWeekdays, day)
+		}
+	}
+	return parsedWeekdays
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseWeekdays(t *testing.T) {
+	for _, tc := range []struct {
+		given    string
+		expected []time.Weekday
+	}{
+		// empty string
+		{
+			"",
+			[]time.Weekday{},
+		},
+		// single weekday
+		{
+			"sat",
+			[]time.Weekday{time.Saturday},
+		},
+		// multiple weekdays
+		{
+			"sat,sun",
+			[]time.Weekday{time.Saturday, time.Sunday},
+		},
+		// case-insensitive
+		{
+			"SaT,SUn",
+			[]time.Weekday{time.Saturday, time.Sunday},
+		},
+		// ignore whitespace
+		{
+			" sat , sun ",
+			[]time.Weekday{time.Saturday, time.Sunday},
+		},
+		// ignore unknown weekdays
+		{
+			"sat,unknown,sun",
+			[]time.Weekday{time.Saturday, time.Sunday},
+		},
+		// deal with all kinds at the same time
+		{
+			"Fri, sat ,,,,  ,foobar,tue",
+			[]time.Weekday{time.Friday, time.Saturday, time.Tuesday},
+		},
+	} {
+		got := ParseWeekdays(tc.given)
+
+		if len(tc.expected) != len(got) {
+			t.Fatalf("expected %d, got %d", len(tc.expected), len(got))
+		}
+
+		for i := range tc.expected {
+			if tc.expected[i] != got[i] {
+				t.Errorf("expected %v, got %v", tc.expected[i], got[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is an alternative implementation of solely the weekday filter proposed in https://github.com/linki/chaoskube/pull/54. In my opinion it's simpler to understand and maintain than https://github.com/linki/chaoskube/pull/54 (It also does less at this point).

It adds a flag to specify a list of weekdays when chaoskube doesn't terminate any pods, e.g. specifying `--excluded-weekdays "sat,sun"` would prevent any chaos on the weekend. I picked the `exclude-`-approach so that the default empty `--excluded-weekdays=""` would behave as before.

@klautcomputing @twildeboer This idea comes directly from your PRs  https://github.com/linki/chaoskube/pull/47 and https://github.com/linki/chaoskube/pull/54 but I focused on the weekday filter first in order to keep it simpe. I intend to look through your PRs and use them to come up with something similar for the "run-at-this-time-of-day"-flag (i.e. the `--chaos-hrs`). I hope you don't mind.

@klautcomputing @twildeboer let me know what you think about this one.