### PR TITLE
Add certificates and timezone info to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN go build -o /bin/chaoskube -v \
 FROM alpine:3.6
 MAINTAINER Linki <linki+docker.com@posteo.de>
 
-RUN apk --no-cache add dumb-init && addgroup -S chaoskube && adduser -S -g chaoskube chaoskube
+RUN apk --no-cache add ca-certificates dumb-init
+RUN addgroup -S chaoskube && adduser -S -g chaoskube chaoskube
+COPY --from=builder /usr/local/go/lib/time/zoneinfo.zip /usr/local/go/lib/time/zoneinfo.zip
 COPY --from=builder /bin/chaoskube /bin/chaoskube
 
 USER chaoskube


### PR DESCRIPTION
current image
* fails to connect to AWS clusters
* cannot read timezone information other than Local and UTC