### PR TITLE
Allow to specify daily time periods without chaos

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -429,6 +429,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "19cccced3092feb4b8fed7307518f596638f3d91e61e5b1ad903de408c33508d"
+  inputs-digest = "2a1d3b752d03531124dcf7a6afccc5afb2cc93d2afec34d6d4422e7536950f0c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ INFO[4804] Killing pod chaoskube/nginx-701339712-51nt8
 ...
 ```
 
-`chaoskube` allows to filter target pods by namespaces, labels and annotations.
-[See below](#filtering-targets) for details.
+`chaoskube` allows to filter target pods [by namespaces, labels and annotations](#filtering-targets) as well as [exclude certain weekdays or times of day](###limiting-the-chaos) from chaos.
 
 ## How
 
@@ -141,19 +140,24 @@ spec:
 
 ## Limiting the Chaos
 
-You can limit the time when chaos is introduced. To turn on this feature, add a comma-separated list of abbreviated weekdays via the `--excluded-weekdays` option and specify a `--timezone` in which to interpret those weekdays. Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). If you're testing `chaoskube` from your local machine then `Local` makes the most sense. Once you deploy `chaoskube` to your cluster you should deploy it with a specific timezone, e.g. where most of your team members are living, so that both your team and `chaoskube` have a common understanding when a particular weekday begins and ends. If your team is spread across multiple time zones it's probably best to pick `UTC` which is also the default. Picking the wrong timezone shifts the meaning of, e.g., Saturday by a couple of hours between you and the server.
+You can limit the time when chaos is introduced by weekdays, time periods of a day or both.
+
+Add a comma-separated list of abbreviated weekdays via the `--excluded-weekdays` options and/or a comma-separated list of time periods via the `--excluded-times-of-day` option and specify a `--timezone` in which to interpret them by.
+
+Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). If you're testing `chaoskube` from your local machine then `Local` makes the most sense. Once you deploy `chaoskube` to your cluster you should deploy it with a specific timezone, e.g. where most of your team members are living, so that both your team and `chaoskube` have a common understanding when a particular weekday begins and ends, for instance. If your team is spread across multiple time zones it's probably best to pick `UTC` which is also the default. Picking the wrong timezone shifts the meaning of a particular weekday by a couple of hours between you and the server.
 
 ## Flags
 
-| Option                | Description                                                          | Default                |
-|-----------------------|----------------------------------------------------------------------|------------------------|
-| `--interval`          | interval between pod terminations                                    | 10m                    |
-| `--labels`            | label selector to filter pods by                                     | (matches everything)   |
-| `--annotations`       | annotation selector to filter pods by                                | (matches everything)   |
-| `--namespaces`        | namespace selector to filter pods by                                 | (all namespaces)       |
-| `--excluded-weekdays` | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)  |
-| `--timezone`          | timezone from tz database, e.g. "America/New_York", "UTC" or "Local" | (UTC)                  |
-| `--dry-run`           | don't kill pods, only log what would have been done                  | true                   |
+| Option                    | Description                                                          | Default                    |
+|---------------------------|----------------------------------------------------------------------|----------------------------|
+| `--interval`              | interval between pod terminations                                    | 10m                        |
+| `--labels`                | label selector to filter pods by                                     | (matches everything)       |
+| `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
+| `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
+| `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |
+| `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "10:00PM-08:00AM"   | (no times of day excluded) |
+| `--timezone`              | timezone from tz database, e.g. "America/New_York", "UTC" or "Local" | (UTC)                      |
+| `--dry-run`               | don't kill pods, only log what would have been done                  | true                       |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ INFO[4804] Killing pod chaoskube/nginx-701339712-51nt8
 ...
 ```
 
-`chaoskube` allows to filter target pods [by namespaces, labels and annotations](#filtering-targets) as well as [exclude certain weekdays or times of day](###limiting-the-chaos) from chaos.
+`chaoskube` allows to filter target pods [by namespaces, labels and annotations](#filtering-targets) as well as [exclude certain weekdays or times of day](#limit-the-chaos) from chaos.
 
 ## How
 
@@ -138,7 +138,7 @@ spec:
       ...
 ```
 
-## Limiting the Chaos
+## Limit the Chaos
 
 You can limit the time when chaos is introduced by weekdays, time periods of a day or both.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
 | `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |
-| `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "10:00PM-08:00AM"   | (no times of day excluded) |
+| `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "22:00-08:00"       | (no times of day excluded) |
 | `--timezone`              | timezone from tz database, e.g. "America/New_York", "UTC" or "Local" | (UTC)                      |
 | `--dry-run`               | don't kill pods, only log what would have been done                  | true                       |
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ spec:
 
 You can limit the time when chaos is introduced by weekdays, time periods of a day or both.
 
-Add a comma-separated list of abbreviated weekdays via the `--excluded-weekdays` options and/or a comma-separated list of time periods via the `--excluded-times-of-day` option and specify a `--timezone` in which to interpret them by.
+Add a comma-separated list of abbreviated weekdays via the `--excluded-weekdays` options and/or a comma-separated list of time periods via the `--excluded-times-of-day` option and specify a `--timezone` by which to interpret them.
 
 Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). If you're testing `chaoskube` from your local machine then `Local` makes the most sense. Once you deploy `chaoskube` to your cluster you should deploy it with a specific timezone, e.g. where most of your team members are living, so that both your team and `chaoskube` have a common understanding when a particular weekday begins and ends, for instance. If your team is spread across multiple time zones it's probably best to pick `UTC` which is also the default. Picking the wrong timezone shifts the meaning of a particular weekday by a couple of hours between you and the server.
 

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func init() {
 	kingpin.Flag("annotations", "A set of annotations to restrict the list of affected pods. Defaults to everything.").StringVar(&annString)
 	kingpin.Flag("namespaces", "A set of namespaces to restrict the list of affected pods. Defaults to everything.").StringVar(&nsString)
 	kingpin.Flag("excluded-weekdays", "A list of weekdays when termination is suspended, e.g. sat,sun").StringVar(&excludedWeekdays)
-	kingpin.Flag("excluded-times-of-day", "A list of time periods of a day when termination is suspended, e.g. 10:00PM-08:00AM").StringVar(&excludedTimesOfDay)
+	kingpin.Flag("excluded-times-of-day", "A list of time periods of a day when termination is suspended, e.g. 22:00-08:00").StringVar(&excludedTimesOfDay)
 	kingpin.Flag("timezone", "The timezone by which to interpret the excluded weekdays and times of day, e.g. UTC, Local, Europe/Berlin. Defaults to UTC.").Default("UTC").StringVar(&timezone)
 	kingpin.Flag("master", "The address of the Kubernetes cluster to target").StringVar(&master)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").StringVar(&kubeconfig)

--- a/util/util.go
+++ b/util/util.go
@@ -9,6 +9,11 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+const (
+	// a short time format; like time.Kitchen but with 24-hour notation.
+	timeFormatKitchen24 = "15:04"
+)
+
 // TimePeriod represents a time period with a single beginning and end.
 type TimePeriod struct {
 	From time.Time
@@ -36,7 +41,7 @@ func (tp TimePeriod) Includes(pointInTime time.Time) bool {
 
 // String returns tp as a pretty string.
 func (tp TimePeriod) String() string {
-	return fmt.Sprintf("%s-%s", tp.From.Format(time.Kitchen), tp.To.Format(time.Kitchen))
+	return fmt.Sprintf("%s-%s", tp.From.Format(timeFormatKitchen24), tp.To.Format(timeFormatKitchen24))
 }
 
 // ParseWeekdays takes a comma-separated list of abbreviated weekdays (e.g. sat,sun) and turns them
@@ -61,8 +66,8 @@ func ParseWeekdays(weekdays string) []time.Weekday {
 	return parsedWeekdays
 }
 
-// ParseTimePeriods takes a comma-separated list of time periods in time.Kitchen-time.Kitchen format
-// and turns them into a slice of TimePeriods. It ignores any whitespace.
+// ParseTimePeriods takes a comma-separated list of time periods in Kitchen24 format and turns them
+// into a slice of TimePeriods. It ignores any whitespace.
 func ParseTimePeriods(timePeriods string) ([]TimePeriod, error) {
 	parsedTimePeriods := []TimePeriod{}
 
@@ -72,12 +77,12 @@ func ParseTimePeriods(timePeriods string) ([]TimePeriod, error) {
 			continue
 		}
 
-		begin, err := time.ParseInLocation(time.Kitchen, strings.TrimSpace(parts[0]), time.Local)
+		begin, err := time.ParseInLocation(timeFormatKitchen24, strings.TrimSpace(parts[0]), time.Local)
 		if err != nil {
 			return nil, err
 		}
 
-		end, err := time.ParseInLocation(time.Kitchen, strings.TrimSpace(parts[1]), time.Local)
+		end, err := time.ParseInLocation(timeFormatKitchen24, strings.TrimSpace(parts[1]), time.Local)
 		if err != nil {
 			return nil, err
 		}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -100,14 +100,13 @@ func TestTimePeriodIncludes(t *testing.T) {
 			atTheMoment,
 			false,
 		},
-
-		// it's just inside 2
+		// it's slightly inside before day switch
 		{
 			time.Date(1869, 9, 23, 23, 30, 00, 00, time.UTC),
 			midnight,
 			true,
 		},
-		// it's just inside 1
+		// it's slightly inside after day switch
 		{
 			time.Date(1869, 9, 24, 00, 30, 00, 00, time.UTC),
 			midnight,
@@ -195,10 +194,12 @@ func TestTimeOfDay(t *testing.T) {
 		pointInTime time.Time
 		expected    time.Time
 	}{
+		// strips of any day information
 		{
 			time.Date(1869, 9, 24, 15, 04, 05, 06, time.UTC),
 			time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),
 		},
+		// it normalizes to UTC timezone
 		{
 			time.Date(1869, 9, 24, 15, 04, 05, 06, timezone),
 			time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,9 +1,215 @@
 package util
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
+
+func TestNewTimePeriod(t *testing.T) {
+	timezone, err := time.LoadLocation("Australia/Brisbane")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		from     time.Time
+		to       time.Time
+		expected TimePeriod
+	}{
+		// when it's already normalized
+		{
+			time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),
+			time.Date(0, 0, 0, 16, 04, 05, 06, time.UTC),
+			TimePeriod{
+				From: time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),
+				To:   time.Date(0, 0, 0, 16, 04, 05, 06, time.UTC),
+			},
+		},
+		// it normalizes to very first day
+		{
+			time.Date(1869, 9, 24, 15, 04, 05, 06, time.UTC),
+			time.Date(1869, 9, 24, 16, 04, 05, 06, time.UTC),
+			TimePeriod{
+				From: time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),
+				To:   time.Date(0, 0, 0, 16, 04, 05, 06, time.UTC),
+			},
+		},
+		// it ignores the timezone
+		{
+			time.Date(1869, 9, 24, 15, 04, 05, 06, timezone),
+			time.Date(1869, 9, 24, 16, 04, 05, 06, timezone),
+			TimePeriod{
+				From: time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),
+				To:   time.Date(0, 0, 0, 16, 04, 05, 06, time.UTC),
+			},
+		},
+	} {
+		got := NewTimePeriod(tc.from, tc.to)
+		if tc.expected.From != got.From {
+			t.Fatalf("expected %v, got %v", tc.expected, got)
+		}
+		if tc.expected.To != got.To {
+			t.Fatalf("expected %v, got %v", tc.expected, got)
+		}
+	}
+}
+
+func TestTimePeriodIncludes(t *testing.T) {
+	atTheMoment := NewTimePeriod(time.Now().Add(-1*time.Minute), time.Now().Add(+1*time.Minute))
+
+	midnight := NewTimePeriod(
+		time.Date(1869, 9, 23, 23, 00, 00, 00, time.UTC),
+		time.Date(1869, 9, 24, 01, 00, 00, 00, time.UTC),
+	)
+
+	now := time.Now()
+
+	for _, tc := range []struct {
+		pointInTime time.Time
+		timeOfDay   TimePeriod
+		expected    bool
+	}{
+		// it's included
+		{
+			now,
+			atTheMoment,
+			true,
+		},
+		// it's one day before
+		{
+			now.Add(-24 * time.Hour),
+			atTheMoment,
+			true,
+		},
+		// it's one day after
+		{
+			now.Add(+24 * time.Hour),
+			atTheMoment,
+			true,
+		},
+		// it's just before
+		{
+			now.Add(-2 * time.Minute),
+			atTheMoment,
+			false,
+		},
+		// it's just after
+		{
+			now.Add(+2 * time.Minute),
+			atTheMoment,
+			false,
+		},
+
+		// it's just inside 2
+		{
+			time.Date(1869, 9, 23, 23, 30, 00, 00, time.UTC),
+			midnight,
+			true,
+		},
+		// it's just inside 1
+		{
+			time.Date(1869, 9, 24, 00, 30, 00, 00, time.UTC),
+			midnight,
+			true,
+		},
+		// it's just before
+		{
+			time.Date(1869, 9, 23, 22, 30, 00, 00, time.UTC),
+			midnight,
+			false,
+		},
+		// it's just after
+		{
+			time.Date(1869, 9, 24, 01, 30, 00, 00, time.UTC),
+			midnight,
+			false,
+		},
+		// it's exactly matching a point in time
+		{
+			now,
+			TimePeriod{From: TimeOfDay(now), To: TimeOfDay(now)},
+			true,
+		},
+		// it's right after exactly matching a point in time
+		{
+			now.Add(+1 * time.Second),
+			TimePeriod{From: TimeOfDay(now), To: TimeOfDay(now)},
+			false,
+		},
+		// it's right before exactly matching a point in time
+		{
+			now.Add(-1 * time.Second),
+			TimePeriod{From: TimeOfDay(now), To: TimeOfDay(now)},
+			false,
+		},
+	} {
+		got := tc.timeOfDay.Includes(tc.pointInTime)
+		if tc.expected != got {
+			t.Errorf("expected %v, got %v", tc.expected, got)
+		}
+	}
+}
+
+func TestTimePeriodString(t *testing.T) {
+	for _, tc := range []struct {
+		given    TimePeriod
+		expected string
+	}{
+		// empty time period
+		{
+			TimePeriod{},
+			"12:00AM-12:00AM",
+		},
+		// simple time period
+		{
+			TimePeriod{
+				From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
+				To:   time.Date(0, 0, 0, 16, 0, 0, 0, time.UTC),
+			},
+			"8:00AM-4:00PM",
+		},
+		// time period across days
+		{
+			TimePeriod{
+				From: time.Date(0, 0, 0, 16, 0, 0, 0, time.UTC),
+				To:   time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
+			},
+			"4:00PM-8:00AM",
+		},
+	} {
+		got := fmt.Sprintf("%s", tc.given)
+		if tc.expected != got {
+			t.Fatalf("expected %s, got %s", tc.expected, got)
+		}
+	}
+}
+
+func TestTimeOfDay(t *testing.T) {
+	timezone, err := time.LoadLocation("Australia/Brisbane")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		pointInTime time.Time
+		expected    time.Time
+	}{
+		{
+			time.Date(1869, 9, 24, 15, 04, 05, 06, time.UTC),
+			time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),
+		},
+		{
+			time.Date(1869, 9, 24, 15, 04, 05, 06, timezone),
+			time.Date(0, 0, 0, 15, 04, 05, 06, time.UTC),
+		},
+	} {
+		got := TimeOfDay(tc.pointInTime)
+		if tc.expected != got {
+			t.Fatalf("expected %v, got %v", tc.expected, got)
+		}
+	}
+}
 
 func TestParseWeekdays(t *testing.T) {
 	for _, tc := range []struct {
@@ -47,6 +253,72 @@ func TestParseWeekdays(t *testing.T) {
 		},
 	} {
 		got := ParseWeekdays(tc.given)
+
+		if len(tc.expected) != len(got) {
+			t.Fatalf("expected %d, got %d", len(tc.expected), len(got))
+		}
+
+		for i := range tc.expected {
+			if tc.expected[i] != got[i] {
+				t.Errorf("expected %v, got %v", tc.expected[i], got[i])
+			}
+		}
+	}
+}
+
+func TestParseTimePeriods(t *testing.T) {
+	for _, tc := range []struct {
+		given    string
+		expected []TimePeriod
+	}{
+		// empty time period string
+		{
+			"",
+			[]TimePeriod{},
+		},
+		// single range string
+		{
+			"08:00AM-04:00PM",
+			[]TimePeriod{
+				{
+					From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
+					To:   time.Date(0, 0, 0, 16, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+		// multiple ranges string
+		{
+			"08:00AM-04:00PM,08:00PM-10:00PM",
+			[]TimePeriod{
+				{
+					From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
+					To:   time.Date(0, 0, 0, 16, 0, 0, 0, time.UTC),
+				},
+				{
+					From: time.Date(0, 0, 0, 20, 0, 0, 0, time.UTC),
+					To:   time.Date(0, 0, 0, 22, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+		// string containing whitespace
+		{
+			" 08:00AM - 04:00PM ,, , 08:00PM - 10:00PM ",
+			[]TimePeriod{
+				{
+					From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
+					To:   time.Date(0, 0, 0, 16, 0, 0, 0, time.UTC),
+				},
+				{
+					From: time.Date(0, 0, 0, 20, 0, 0, 0, time.UTC),
+					To:   time.Date(0, 0, 0, 22, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	} {
+		got, err := ParseTimePeriods(tc.given)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		if len(tc.expected) != len(got) {
 			t.Fatalf("expected %d, got %d", len(tc.expected), len(got))

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -158,7 +158,7 @@ func TestTimePeriodString(t *testing.T) {
 		// empty time period
 		{
 			TimePeriod{},
-			"12:00AM-12:00AM",
+			"00:00-00:00",
 		},
 		// simple time period
 		{
@@ -166,7 +166,7 @@ func TestTimePeriodString(t *testing.T) {
 				From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
 				To:   time.Date(0, 0, 0, 16, 0, 0, 0, time.UTC),
 			},
-			"8:00AM-4:00PM",
+			"08:00-16:00",
 		},
 		// time period across days
 		{
@@ -174,7 +174,7 @@ func TestTimePeriodString(t *testing.T) {
 				From: time.Date(0, 0, 0, 16, 0, 0, 0, time.UTC),
 				To:   time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
 			},
-			"4:00PM-8:00AM",
+			"16:00-08:00",
 		},
 	} {
 		got := fmt.Sprintf("%s", tc.given)
@@ -279,7 +279,7 @@ func TestParseTimePeriods(t *testing.T) {
 		},
 		// single range string
 		{
-			"08:00AM-04:00PM",
+			"08:00-16:00",
 			[]TimePeriod{
 				{
 					From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
@@ -289,7 +289,7 @@ func TestParseTimePeriods(t *testing.T) {
 		},
 		// multiple ranges string
 		{
-			"08:00AM-04:00PM,08:00PM-10:00PM",
+			"08:00-16:00,20:00-22:00",
 			[]TimePeriod{
 				{
 					From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),
@@ -303,7 +303,7 @@ func TestParseTimePeriods(t *testing.T) {
 		},
 		// string containing whitespace
 		{
-			" 08:00AM - 04:00PM ,, , 08:00PM - 10:00PM ",
+			" 08:00 - 16:00 ,, , 20:00 - 22:00 ",
 			[]TimePeriod{
 				{
 					From: time.Date(0, 0, 0, 8, 0, 0, 0, time.UTC),


### PR DESCRIPTION
allows to specify time periods per day that chaoskube is inactive, e.g.
```
--excluded-times-of-day="11:00-13:00,22:00-06:00"
```