### PR TITLE
Raise error on malformed time range

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -72,9 +72,13 @@ func ParseTimePeriods(timePeriods string) ([]TimePeriod, error) {
 	parsedTimePeriods := []TimePeriod{}
 
 	for _, tp := range strings.Split(timePeriods, ",") {
+		if strings.TrimSpace(tp) == "" {
+			continue
+		}
+
 		parts := strings.Split(tp, "-")
 		if len(parts) != 2 {
-			continue
+			return nil, fmt.Errorf("Invalid time range '%v': must contain exactly one '-'", tp)
 		}
 
 		begin, err := time.ParseInLocation(timeFormatKitchen24, strings.TrimSpace(parts[0]), time.Local)

--- a/util/util.go
+++ b/util/util.go
@@ -81,12 +81,12 @@ func ParseTimePeriods(timePeriods string) ([]TimePeriod, error) {
 			return nil, fmt.Errorf("Invalid time range '%v': must contain exactly one '-'", tp)
 		}
 
-		begin, err := time.ParseInLocation(timeFormatKitchen24, strings.TrimSpace(parts[0]), time.Local)
+		begin, err := time.Parse(timeFormatKitchen24, strings.TrimSpace(parts[0]))
 		if err != nil {
 			return nil, err
 		}
 
-		end, err := time.ParseInLocation(timeFormatKitchen24, strings.TrimSpace(parts[1]), time.Local)
+		end, err := time.Parse(timeFormatKitchen24, strings.TrimSpace(parts[1]))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Also ignores the time zone when merely parsing a string into a struct.