### PR TITLE
Allow to exclude certain dates from chaos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ INFO[4804] Killing pod chaoskube/nginx-701339712-51nt8
 ...
 ```
 
-`chaoskube` allows to filter target pods [by namespaces, labels and annotations](#filtering-targets) as well as [exclude certain weekdays or times of day](#limit-the-chaos) from chaos.
+`chaoskube` allows to filter target pods [by namespaces, labels and annotations](#filtering-targets) as well as [exclude certain weekdays, times of day and days of a year](#limit-the-chaos) from chaos.
 
 ## How
 
@@ -140,9 +140,9 @@ spec:
 
 ## Limit the Chaos
 
-You can limit the time when chaos is introduced by weekdays, time periods of a day or both.
+You can limit the time when chaos is introduced by weekdays, time periods of a day, day of a year or all of them together.
 
-Add a comma-separated list of abbreviated weekdays via the `--excluded-weekdays` options and/or a comma-separated list of time periods via the `--excluded-times-of-day` option and specify a `--timezone` by which to interpret them.
+Add a comma-separated list of abbreviated weekdays via the `--excluded-weekdays` options, a comma-separated list of time periods via the `--excluded-times-of-day` option and/or a comma-separated list of days of a year via the `--excluded-days-of-year` option and specify a `--timezone` by which to interpret them.
 
 Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). If you're testing `chaoskube` from your local machine then `Local` makes the most sense. Once you deploy `chaoskube` to your cluster you should deploy it with a specific timezone, e.g. where most of your team members are living, so that both your team and `chaoskube` have a common understanding when a particular weekday begins and ends, for instance. If your team is spread across multiple time zones it's probably best to pick `UTC` which is also the default. Picking the wrong timezone shifts the meaning of a particular weekday by a couple of hours between you and the server.
 
@@ -156,6 +156,7 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
 | `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |
 | `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "22:00-08:00"       | (no times of day excluded) |
+| `--excluded-days-of-year` | days of a year when chaos is to be suspended, e.g. "Apr1,Dec24"      | (no days of year excluded) |
 | `--timezone`              | timezone from tz database, e.g. "America/New_York", "UTC" or "Local" | (UTC)                      |
 | `--dry-run`               | don't kill pods, only log what would have been done                  | true                       |
 

--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,8 @@ import (
 const (
 	// a short time format; like time.Kitchen but with 24-hour notation.
 	Kitchen24 = "15:04"
+	// a time format that just cares about the day and month.
+	YearDay = "Jan_2"
 )
 
 // TimePeriod represents a time period with a single beginning and end.
@@ -95,6 +97,25 @@ func ParseTimePeriods(timePeriods string) ([]TimePeriod, error) {
 	}
 
 	return parsedTimePeriods, nil
+}
+
+func ParseDays(days string) ([]time.Time, error) {
+	parsedDays := []time.Time{}
+
+	for _, day := range strings.Split(days, ",") {
+		if strings.TrimSpace(day) == "" {
+			continue
+		}
+
+		parsedDay, err := time.Parse(YearDay, strings.TrimSpace(day))
+		if err != nil {
+			return nil, err
+		}
+
+		parsedDays = append(parsedDays, parsedDay)
+	}
+
+	return parsedDays, nil
 }
 
 // TimeOfDay normalizes the given point in time by returning a time object that represents the same

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -300,6 +300,71 @@ func (suite *Suite) TestParseTimePeriods() {
 	}
 }
 
+func (suite *Suite) TestParseDates() {
+	for _, tt := range []struct {
+		given    string
+		expected []time.Time
+	}{
+		// empty string
+		{
+			"",
+			[]time.Time{},
+		},
+		// single date
+		{
+			"Apr 1",
+			[]time.Time{
+				time.Date(0, 4, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		// single date leaving out the space
+		{
+			"Apr1",
+			[]time.Time{
+				time.Date(0, 4, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		// multiple dates
+		{
+			"Apr 1,Dec 24",
+			[]time.Time{
+				time.Date(0, 4, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(0, 12, 24, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		// case-insensitive
+		{
+			"apr 1,dEc 24",
+			[]time.Time{
+				time.Date(0, 4, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(0, 12, 24, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		// ignore whitespace
+		{
+			" apr 1 , dec 24 ",
+			[]time.Time{
+				time.Date(0, 4, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(0, 12, 24, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		// deal with all kinds at the same time
+		{
+			",Apr 1, dEc 24 ,,,,  ,jun08,,",
+			[]time.Time{
+				time.Date(0, 4, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(0, 12, 24, 0, 0, 0, 0, time.UTC),
+				time.Date(0, 6, 8, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	} {
+		days, err := ParseDays(tt.given)
+		suite.Require().NoError(err)
+
+		suite.Equal(tt.expected, days)
+	}
+}
+
 func TestSuite(t *testing.T) {
 	suite.Run(t, new(Suite))
 }


### PR DESCRIPTION
There's one last feature contained in https://github.com/linki/chaoskube/pull/55 about excluding certain dates. Porting it over to the latest master.