### PR TITLE
Use roveralls to aggregate coverage results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ go:
 
 install:
 - go get github.com/mattn/goveralls
+- go get github.com/lawrencewoodman/roveralls
 - go get github.com/golang/dep/cmd/dep
 - dep ensure -vendor-only
 
 script:
-- goveralls -service=travis-ci -v
+- roveralls
+- goveralls -coverprofile=roveralls.coverprofile -service=travis-ci


### PR DESCRIPTION
The test coverage reporting doesn't really reflect what the entire test suite covers, e.g. see https://coveralls.io/builds/16412411/source?filename=util%2Futil.go

`roveralls` is supposed to fix that by aggregating the per-package cover reports.