### PR TITLE
Only consider running pods as possible victims

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -151,10 +151,7 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 		return nil, err
 	}
 
-	pods, err = filterByAnnotations(pods, c.Annotations)
-	if err != nil {
-		return nil, err
-	}
+	pods = filterByAnnotations(pods, c.Annotations)
 
 	return pods, nil
 }
@@ -231,10 +228,10 @@ func filterByNamespaces(pods []v1.Pod, namespaces labels.Selector) ([]v1.Pod, er
 }
 
 // filterByAnnotations filters a list of pods by a given annotation selector.
-func filterByAnnotations(pods []v1.Pod, annotations labels.Selector) ([]v1.Pod, error) {
+func filterByAnnotations(pods []v1.Pod, annotations labels.Selector) []v1.Pod {
 	// empty filter returns original list
 	if annotations.Empty() {
-		return pods, nil
+		return pods
 	}
 
 	filteredList := []v1.Pod{}
@@ -249,5 +246,5 @@ func filterByAnnotations(pods []v1.Pod, annotations labels.Selector) ([]v1.Pod, 
 		}
 	}
 
-	return filteredList, nil
+	return filteredList
 }

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -152,6 +152,7 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	}
 
 	pods = filterByAnnotations(pods, c.Annotations)
+	pods = filterByPhase(pods, v1.PodRunning)
 
 	return pods, nil
 }
@@ -242,6 +243,19 @@ func filterByAnnotations(pods []v1.Pod, annotations labels.Selector) []v1.Pod {
 
 		// include pod if its annotations match the selector
 		if annotations.Matches(selector) {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList
+}
+
+// filterByPhase filters a list of pods by a given PodPhase, e.g. Running.
+func filterByPhase(pods []v1.Pod, phase v1.PodPhase) []v1.Pod {
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		if pod.Status.Phase == phase {
 			filteredList = append(filteredList, pod)
 		}
 	}

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -187,7 +187,7 @@ func (suite *Suite) TestDeletePod() {
 			tt.dryRun,
 		)
 
-		victim := util.NewPod("default", "foo")
+		victim := util.NewPod("default", "foo", v1.PodRunning)
 
 		err := chaoskube.DeletePod(victim)
 		suite.Require().NoError(err)
@@ -499,8 +499,9 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 	)
 
 	pods := []v1.Pod{
-		util.NewPod("default", "foo"),
-		util.NewPod("testing", "bar"),
+		util.NewPod("default", "foo", v1.PodRunning),
+		util.NewPod("testing", "bar", v1.PodRunning),
+		util.NewPod("testing", "baz", v1.PodPending), // Non-running pods are ignored
 	}
 
 	for _, pod := range pods {

--- a/util/util.go
+++ b/util/util.go
@@ -125,7 +125,7 @@ func TimeOfDay(pointInTime time.Time) time.Time {
 }
 
 // NewPod returns a new pod instance for testing purposes.
-func NewPod(namespace, name string) v1.Pod {
+func NewPod(namespace, name string, phase v1.PodPhase) v1.Pod {
 	return v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -136,6 +136,9 @@ func NewPod(namespace, name string) v1.Pod {
 			Annotations: map[string]string{
 				"chaos": name,
 			},
+		},
+		Status: v1.PodStatus{
+			Phase: phase,
 		},
 	}
 }


### PR DESCRIPTION
This limits the set of possible target pods to the ones that are currently in `Running` phase.

Fixes https://github.com/linki/chaoskube/issues/82

/cc @nsidhaye @Spellchaser