### PR TITLE
Add minimum age check for pods

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -156,7 +156,6 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 
 	pods = filterByAnnotations(pods, c.Annotations)
 	pods = filterByPhase(pods, v1.PodRunning)
-
 	pods = filterByMinimumAge(pods, c.MinimumAge, c.Now())
 
 	return pods, nil

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -111,7 +111,7 @@ func (suite *Suite) TestCandidates() {
 			[]util.TimePeriod{},
 			[]time.Time{},
 			time.UTC,
-			time.Duration(42),
+			time.Duration(0),
 			false,
 		)
 
@@ -145,7 +145,7 @@ func (suite *Suite) TestVictim() {
 			[]util.TimePeriod{},
 			[]time.Time{},
 			time.UTC,
-			time.Duration(42),
+			time.Duration(0),
 			false,
 		)
 
@@ -163,7 +163,7 @@ func (suite *Suite) TestNoVictimReturnsError() {
 		[]util.TimePeriod{},
 		[]time.Time{},
 		time.UTC,
-		time.Duration(42),
+		time.Duration(0),
 		false,
 	)
 
@@ -191,7 +191,7 @@ func (suite *Suite) TestDeletePod() {
 			[]util.TimePeriod{},
 			[]time.Time{},
 			time.UTC,
-			time.Duration(42),
+			time.Duration(0),
 			tt.dryRun,
 		)
 
@@ -421,7 +421,7 @@ func (suite *Suite) TestTerminateVictim() {
 			tt.excludedTimesOfDay,
 			tt.excludedDaysOfYear,
 			tt.timezone,
-			time.Duration(42),
+			time.Duration(0),
 			false,
 		)
 		chaoskube.Now = tt.now
@@ -446,7 +446,7 @@ func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 		[]util.TimePeriod{},
 		[]time.Time{},
 		time.UTC,
-		time.Duration(42),
+		time.Duration(0),
 		false,
 	)
 

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -40,6 +41,7 @@ func (suite *Suite) TestNew() {
 		excludedWeekdays   = []time.Weekday{time.Friday}
 		excludedTimesOfDay = []util.TimePeriod{util.TimePeriod{}}
 		excludedDaysOfYear = []time.Time{time.Now()}
+		minimumAge         = time.Duration(42)
 	)
 
 	chaoskube := New(
@@ -51,6 +53,7 @@ func (suite *Suite) TestNew() {
 		excludedTimesOfDay,
 		excludedDaysOfYear,
 		time.UTC,
+		minimumAge,
 		logger,
 		false,
 	)
@@ -66,6 +69,7 @@ func (suite *Suite) TestNew() {
 	suite.Equal(time.UTC, chaoskube.Timezone)
 	suite.Equal(logger, chaoskube.Logger)
 	suite.Equal(false, chaoskube.DryRun)
+	suite.Equal(minimumAge, chaoskube.MinimumAge)
 }
 
 func (suite *Suite) TestCandidates() {
@@ -108,6 +112,7 @@ func (suite *Suite) TestCandidates() {
 			[]time.Time{},
 			time.UTC,
 			false,
+			time.Duration(42),
 		)
 
 		suite.assertCandidates(chaoskube, tt.pods)
@@ -141,6 +146,7 @@ func (suite *Suite) TestVictim() {
 			[]time.Time{},
 			time.UTC,
 			false,
+			time.Duration(42),
 		)
 
 		suite.assertVictim(chaoskube, tt.victim)
@@ -157,6 +163,7 @@ func (suite *Suite) TestNoVictimReturnsError() {
 		[]util.TimePeriod{},
 		[]time.Time{},
 		time.UTC,
+		time.Duration(42),
 		false,
 	)
 
@@ -185,6 +192,7 @@ func (suite *Suite) TestDeletePod() {
 			[]time.Time{},
 			time.UTC,
 			tt.dryRun,
+			time.Duration(42),
 		)
 
 		victim := util.NewPod("default", "foo", v1.PodRunning)
@@ -414,6 +422,7 @@ func (suite *Suite) TestTerminateVictim() {
 			tt.excludedDaysOfYear,
 			tt.timezone,
 			false,
+			time.Duration(42),
 		)
 		chaoskube.Now = tt.now
 
@@ -437,6 +446,7 @@ func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 		[]util.TimePeriod{},
 		[]time.Time{},
 		time.UTC,
+		time.Duration(42),
 		false,
 	)
 
@@ -486,7 +496,7 @@ func (suite *Suite) assertLog(level log.Level, msg string, fields log.Fields) {
 	}
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, dryRun bool) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, dryRun bool, minimumAge time.Duration) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,
@@ -495,6 +505,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 		excludedTimesOfDay,
 		excludedDaysOfYear,
 		timezone,
+		minimumAge,
 		dryRun,
 	)
 
@@ -512,7 +523,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 	return chaoskube
 }
 
-func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, dryRun bool) *Chaoskube {
+func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool) *Chaoskube {
 	logOutput.Reset()
 
 	return New(
@@ -524,6 +535,7 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 		excludedTimesOfDay,
 		excludedDaysOfYear,
 		timezone,
+		minimumAge,
 		logger,
 		dryRun,
 	)
@@ -540,4 +552,104 @@ type ThankGodItsFriday struct{}
 func (t ThankGodItsFriday) Now() time.Time {
 	blackFriday, _ := time.Parse(time.RFC1123, "Fri, 24 Sep 1869 15:04:05 UTC")
 	return blackFriday
+}
+
+func (suite *Suite) TestMinimumAge() {
+	type pod struct {
+		name         string
+		namespace    string
+		creationTime time.Time
+	}
+
+	for _, tt := range []struct {
+		minimumAge time.Duration
+		now        func() time.Time
+		pods       []pod
+		candidates int
+	}{
+		// no minimum age set
+		{
+			time.Duration(0),
+			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
+			[]pod{
+				{
+					name:         "test1",
+					namespace:    "test",
+					creationTime: time.Date(0, 10, 24, 9, 00, 00, 00, time.UTC),
+				},
+			},
+			1,
+		},
+		// minimum age set, but pod is too young
+		{
+			time.Hour * 1,
+			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
+			[]pod{
+				{
+					name:         "test1",
+					namespace:    "test",
+					creationTime: time.Date(0, 10, 24, 9, 30, 00, 00, time.UTC),
+				},
+			},
+			0,
+		},
+		// one pod is too young, one matches
+		{
+			time.Hour * 1,
+			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
+			[]pod{
+				// too young
+				{
+					name:         "test1",
+					namespace:    "test",
+					creationTime: time.Date(0, 10, 24, 9, 30, 00, 00, time.UTC),
+				},
+				// matches
+				{
+					name:         "test2",
+					namespace:    "test",
+					creationTime: time.Date(0, 10, 23, 8, 00, 00, 00, time.UTC),
+				},
+			},
+			1,
+		},
+		// exact time - should not match
+		{
+			time.Hour * 1,
+			func() time.Time { return time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC) },
+			[]pod{
+				{
+					name:         "test1",
+					namespace:    "test",
+					creationTime: time.Date(0, 10, 24, 10, 00, 00, 00, time.UTC),
+				},
+			},
+			0,
+		},
+	} {
+		chaoskube := suite.setup(
+			labels.Everything(),
+			labels.Everything(),
+			labels.Everything(),
+			[]time.Weekday{},
+			[]util.TimePeriod{},
+			[]time.Time{},
+			time.UTC,
+			tt.minimumAge,
+			false,
+		)
+		chaoskube.Now = tt.now
+
+		for _, p := range tt.pods {
+			pod := util.NewPod(p.namespace, p.name, v1.PodRunning)
+			pod.ObjectMeta.CreationTimestamp = metav1.Time{Time: p.creationTime}
+			_, err := chaoskube.Client.Core().Pods(pod.Namespace).Create(&pod)
+			suite.Require().NoError(err)
+		}
+
+		pods, err := chaoskube.Candidates()
+		suite.Require().NoError(err)
+
+		suite.Len(pods, tt.candidates)
+	}
 }

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -67,9 +67,9 @@ func (suite *Suite) TestNew() {
 	suite.Equal(excludedTimesOfDay, chaoskube.ExcludedTimesOfDay)
 	suite.Equal(excludedDaysOfYear, chaoskube.ExcludedDaysOfYear)
 	suite.Equal(time.UTC, chaoskube.Timezone)
+	suite.Equal(minimumAge, chaoskube.MinimumAge)
 	suite.Equal(logger, chaoskube.Logger)
 	suite.Equal(false, chaoskube.DryRun)
-	suite.Equal(minimumAge, chaoskube.MinimumAge)
 }
 
 func (suite *Suite) TestCandidates() {
@@ -111,8 +111,8 @@ func (suite *Suite) TestCandidates() {
 			[]util.TimePeriod{},
 			[]time.Time{},
 			time.UTC,
-			false,
 			time.Duration(42),
+			false,
 		)
 
 		suite.assertCandidates(chaoskube, tt.pods)
@@ -145,8 +145,8 @@ func (suite *Suite) TestVictim() {
 			[]util.TimePeriod{},
 			[]time.Time{},
 			time.UTC,
-			false,
 			time.Duration(42),
+			false,
 		)
 
 		suite.assertVictim(chaoskube, tt.victim)
@@ -191,8 +191,8 @@ func (suite *Suite) TestDeletePod() {
 			[]util.TimePeriod{},
 			[]time.Time{},
 			time.UTC,
-			tt.dryRun,
 			time.Duration(42),
+			tt.dryRun,
 		)
 
 		victim := util.NewPod("default", "foo", v1.PodRunning)
@@ -421,8 +421,8 @@ func (suite *Suite) TestTerminateVictim() {
 			tt.excludedTimesOfDay,
 			tt.excludedDaysOfYear,
 			tt.timezone,
-			false,
 			time.Duration(42),
+			false,
 		)
 		chaoskube.Now = tt.now
 
@@ -496,7 +496,7 @@ func (suite *Suite) assertLog(level log.Level, msg string, fields log.Fields) {
 	}
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, dryRun bool, minimumAge time.Duration) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	excludedTimesOfDay string
 	excludedDaysOfYear string
 	timezone           string
+	minimumAge         time.Duration
 	master             string
 	kubeconfig         string
 	interval           time.Duration
@@ -46,6 +47,7 @@ func init() {
 	kingpin.Flag("excluded-times-of-day", "A list of time periods of a day when termination is suspended, e.g. 22:00-08:00").StringVar(&excludedTimesOfDay)
 	kingpin.Flag("excluded-days-of-year", "A list of days of a year when termination is suspended, e.g. Apr1,Dec24").StringVar(&excludedDaysOfYear)
 	kingpin.Flag("timezone", "The timezone by which to interpret the excluded weekdays and times of day, e.g. UTC, Local, Europe/Berlin. Defaults to UTC.").Default("UTC").StringVar(&timezone)
+	kingpin.Flag("minimum-age", "Minimum age of pods to consider for termination").Default("0s").DurationVar(&minimumAge)
 	kingpin.Flag("master", "The address of the Kubernetes cluster to target").StringVar(&master)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").StringVar(&kubeconfig)
 	kingpin.Flag("interval", "Interval between Pod terminations").Default("10m").DurationVar(&interval)
@@ -69,6 +71,7 @@ func main() {
 		"excludedTimesOfDay": excludedTimesOfDay,
 		"excludedDaysOfYear": excludedDaysOfYear,
 		"timezone":           timezone,
+		"minimumAge":         minimumAge,
 		"master":             master,
 		"kubeconfig":         kubeconfig,
 		"interval":           interval,
@@ -145,6 +148,7 @@ func main() {
 		parsedTimesOfDay,
 		parsedDaysOfYear,
 		parsedTimezone,
+		minimumAge,
 		log.StandardLogger(),
 		dryRun,
 	)


### PR DESCRIPTION
For #85 

Optionally filter pods based on age, excluding those that are not older than the passed minimum age.

I added a test specifically for the age check. 