### PR TITLE
ignore pods in eviction state

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -156,7 +156,13 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 		return nil, err
 	}
 
+	pods, err = filterByStatus(pods)
+	if err != nil {
+		return nil, err
+	}
+
 	return pods, nil
+
 }
 
 // DeletePod deletes the given pod.
@@ -250,4 +256,19 @@ func filterByAnnotations(pods []v1.Pod, annotations labels.Selector) ([]v1.Pod, 
 	}
 
 	return filteredList, nil
+}
+
+// filterByStatus filters a list of pods by their current state
+func filterByStatus(pods []v1.Pod) ([]v1.Pod, error) {
+
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		if pod.Status.Phase == "Running" {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList, nil
+
 }


### PR DESCRIPTION
if a cluster contains some evicted pods, chaoskube will delete this pods. but this isn't any kind of chaos, because these pods are still down for a while.

```
NAME                             READY     STATUS    RESTARTS   AGE
details-v1-8b76fd56-vg5rl        2/2       Running   0          3d
helloworld-v1-6594dd65f-sl5dm    2/2       Running   0          3d
helloworld-v2-5d75dff749-dp4x6   0/2       Evicted   0          3d
helloworld-v2-5d75dff749-fjrqf   2/2       Running   0          4h
productpage-v1-f45dd5dc8-f6dp8   2/2       Running   0          2d
productpage-v1-f45dd5dc8-pn2v7   0/2       Evicted   0          3d
ratings-v1-5dfd4c6784-j7ctc      2/2       Running   0          3d
reviews-v1-6d6bd67777-82qsw      2/2       Running   0          2d
reviews-v1-6d6bd67777-hzz9v      0/2       Evicted   0          3d
reviews-v2-87b6bd97c-h9jt9       2/2       Running   0          2d
reviews-v2-87b6bd97c-pnb7q       0/2       Evicted   0          3d
reviews-v3-84f474d4c7-x4lbs      2/2       Running   0          3d
```