### PR TITLE
Add simple healthz handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ If you want to increase or decrease the amount of chaos change the interval betw
 
 Remember that `chaoskube` by default kills any pod in all your namespaces, including system pods and itself.
 
+`chaoskube` provides a simple HTTP endpoint that can be used to check that it is running. This can be used for [Kubernetes liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). By default, this listens on port 8080. To disable, pass `--address=""` to `chaoskube`.
+
 ## Filtering targets
 
 However, you can limit the search space of `chaoskube` by providing label, annotation and namespace selectors.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you want to increase or decrease the amount of chaos change the interval betw
 
 Remember that `chaoskube` by default kills any pod in all your namespaces, including system pods and itself.
 
-`chaoskube` provides a simple HTTP endpoint that can be used to check that it is running. This can be used for [Kubernetes liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). By default, this listens on port 8080. To disable, pass `--address=""` to `chaoskube`.
+`chaoskube` provides a simple HTTP endpoint that can be used to check that it is running. This can be used for [Kubernetes liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). By default, this listens on port 8080. To disable, pass `--metrics-address=""` to `chaoskube`.
 
 ## Filtering targets
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var (
 	interval           time.Duration
 	dryRun             bool
 	debug              bool
-	address            string
+	metricsAddress     string
 )
 
 func init() {
@@ -54,7 +54,7 @@ func init() {
 	kingpin.Flag("interval", "Interval between Pod terminations").Default("10m").DurationVar(&interval)
 	kingpin.Flag("dry-run", "If true, don't actually do anything.").Default("true").BoolVar(&dryRun)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&debug)
-	kingpin.Flag("address", "Listening address for health check handler").Default(":8080").StringVar(&address)
+	kingpin.Flag("metrics-address", "Listening address for metrics handler").Default(":8080").StringVar(&metricsAddress)
 }
 
 func main() {
@@ -153,13 +153,13 @@ func main() {
 		dryRun,
 	)
 
-	if address != "" {
+	if metricsAddress != "" {
 		http.HandleFunc("/healthz",
 			func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintln(w, "OK")
 			})
 		go func() {
-			if err := http.ListenAndServe(address, nil); err != nil {
+			if err := http.ListenAndServe(metricsAddress, nil); err != nil {
 				log.WithFields(log.Fields{
 					"err": err,
 				}).Fatal("failed to start HTTP server")


### PR DESCRIPTION
For #93 

This creates a very simple HTTP endpoint to be used for liveness and readiness checks. In this initial version, it only returns OK. In the future, we may want to check additional functionality before returning OK.

We can reuse this listener for things such as prometheus metrics, as mentioned in #23, in the future, if desired.