### PR TITLE
Use versioned funcs of client-go

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -141,7 +141,7 @@ func (c *Chaoskube) Victim() (v1.Pod, error) {
 func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	listOptions := metav1.ListOptions{LabelSelector: c.Labels.String()}
 
-	podList, err := c.Client.Core().Pods(v1.NamespaceAll).List(listOptions)
+	podList, err := c.Client.CoreV1().Pods(v1.NamespaceAll).List(listOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (c *Chaoskube) DeletePod(victim v1.Pod) error {
 		return nil
 	}
 
-	return c.Client.Core().Pods(victim.Namespace).Delete(victim.Name, nil)
+	return c.Client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, nil)
 }
 
 // filterByNamespaces filters a list of pods by a given namespace selector.

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -505,7 +505,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 	}
 
 	for _, pod := range pods {
-		_, err := chaoskube.Client.Core().Pods(pod.Namespace).Create(&pod)
+		_, err := chaoskube.Client.CoreV1().Pods(pod.Namespace).Create(&pod)
 		suite.Require().NoError(err)
 	}
 


### PR DESCRIPTION
I think it's receommended to use the versioned funcs to get the client object.