### PR TITLE
Initial Proemtheus metrics support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -36,6 +36,12 @@
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -73,7 +79,8 @@
     "ptypes/duration",
     "ptypes/timestamp"
   ]
-  revision = "4bd1920723d7b7c925de087aa32e2187708897f7"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/google/gofuzz"
@@ -122,6 +129,12 @@
   version = "1.1.3"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   name = "github.com/modern-go/concurrent"
   packages = ["."]
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
@@ -138,6 +151,42 @@
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -412,6 +461,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2455302b084f40825b4e778901469df1ffff326ff3fa5b708da7362f91c790e5"
+  inputs-digest = "bf2032d0afbea09aafb0db352827c9efe8c39e5479d51fbe38b1d42c70d6b104"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,3 +21,11 @@
 [[constraint]]
   name = "k8s.io/client-go"
   version = "~7.0.0"
+
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "0.8.0"
+
+[[override]]
+  name = "github.com/golang/protobuf"
+  version = "1.1.0"

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -161,10 +162,21 @@ func main() {
 	)
 
 	if metricsAddress != "" {
+		http.Handle("/metrics", promhttp.Handler())
 		http.HandleFunc("/healthz",
 			func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintln(w, "OK")
 			})
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`<html>
+					<head><title>chaoskube</title></head>
+					<body>
+					<h1>chaoskube</h1>
+					<p><a href="/metrics">Metrics</a></p>
+					<p><a href="/healthz">Health Check</a></p>
+					</body>
+					</html>`))
+		})
 		go func() {
 			if err := http.ListenAndServe(metricsAddress, nil); err != nil {
 				log.WithFields(log.Fields{


### PR DESCRIPTION
This is based on #93 which added the HTTP listener.

This adds the Prometheus metrics handler but does not record any application specific metrics.  I think we may want to wait until #95 is merged before adding metrics as that PR changed the structure of how the loop is ran.

I had to "fix" the protobuf dependency to get this to work with the addition of Prometheus.