### PR TITLE
Add prometheus metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -156,10 +156,10 @@
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
+    "prometheus/promauto",
     "prometheus/promhttp"
   ]
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  revision = "3653aff4d509dd87a6ba41b82d57c0c662733e14"
 
 [[projects]]
   branch = "master"
@@ -461,6 +461,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bf2032d0afbea09aafb0db352827c9efe8c39e5479d51fbe38b1d42c70d6b104"
+  inputs-digest = "e6d36cabd191aaf85d9202563752292e05e0f7372bd611af9c4f366aef4050dc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "0.8.0"
+  revision = "3653aff4d509dd87a6ba41b82d57c0c662733e14"
 
 [[override]]
   name = "github.com/golang/protobuf"

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// PodsDeletedCounter is the pods deleted counter
+	PodsDeletedCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "pods_deleted",
+		Help: "The total number of pods deleted",
+	})
+	// RunCounter is the run function executions counter
+	RunCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "run_counts",
+		Help: "The total number of pod termination logic runs",
+	})
+	// ErrorCounter is the run function executions counter
+	ErrorCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "termination_errors",
+		Help: "The total number of errors on terminate victim operation",
+	})
+	// errorCounter is the run function executions counter
+	TerminationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "termination_time_milliseconds",
+		Help: "The time took single pod termination to finish",
+	})
+)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,7 +23,7 @@ var (
 	})
 	// errorCounter is the run function executions counter
 	TerminationHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name: "termination_time_milliseconds",
+		Name: "termination_time_seconds",
 		Help: "The time took single pod termination to finish",
 	})
 )


### PR DESCRIPTION
Change prometheus package to use latest master (locked by revision as advised in [repo](https://github.com/prometheus/client_golang)) to take advantage of promauto.

Added basic app instrumentation metrics:
1. Run counter
2. Error counter
3. PodsDeleted counter
4. Pod Deletion timers

That's how it looks:

![image](https://user-images.githubusercontent.com/10139826/44734837-7f0af700-aaf3-11e8-8361-43fd0ba4ebd8.png)

My first PR in Golang, so I'm happy to get some comments and improvements.

I can also implement that with some channels, and it'll be a good start to plugin a slack notifications.

Thoughts?