### PR TITLE
Initial sketch of --exec

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,6 +67,17 @@
   revision = "01aeca54ebda6e0fbfafd0a524d234159c05ec20"
 
 [[projects]]
+  branch = "master"
+  digest = "1:d6c13a378213e3de60445e49084b8a0a9ce582776dfc77927775dbeb3ff72a35"
+  name = "github.com/docker/spdystream"
+  packages = [
+    ".",
+    "spdy",
+  ]
+  pruneopts = ""
+  revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
+
+[[projects]]
   digest = "1:a31fbb19d2b38d50bc125d97b7c3e7a286d3f6f37d18756011eb6e7d1a9fa7d0"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -428,9 +439,12 @@
     "pkg/util/clock",
     "pkg/util/errors",
     "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/httpstream/spdy",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/net",
+    "pkg/util/remotecommand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/validation",
@@ -439,6 +453,7 @@
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
@@ -529,8 +544,11 @@
     "tools/clientcmd/api/v1",
     "tools/metrics",
     "tools/reference",
+    "tools/remotecommand",
     "transport",
+    "transport/spdy",
     "util/cert",
+    "util/exec",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
@@ -557,8 +575,10 @@
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth",
+    "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/reference",
+    "k8s.io/client-go/tools/remotecommand",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/chaoskube/action.go
+++ b/chaoskube/action.go
@@ -1,0 +1,103 @@
+package chaoskube
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/remotecommand"
+	"os"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes/scheme"
+	"fmt"
+)
+
+type ChaosAction interface {
+	// Imbue chaos in the given victim
+	ApplyChaos(victim v1.Pod) error
+	// Name of this action, ideally a verb - like "terminate pod"
+	Name() string
+}
+
+func NewDryRunAction() ChaosAction {
+	return &dryRun{}
+}
+
+func NewDeletePodAction(client kubernetes.Interface) ChaosAction {
+	return &deletePod{client}
+}
+
+func NewExecAction(client restclient.Interface, config *restclient.Config, containerName string, command []string) ChaosAction {
+	return &execOnPod{client, config, containerName, command}
+}
+
+// no-op
+type dryRun struct {
+
+}
+func (s *dryRun) ApplyChaos(victim v1.Pod) error {
+	return nil
+}
+func (s *dryRun) Name() string { return "dry run" }
+
+var _ ChaosAction = &dryRun{}
+
+// Simply ask k8s to delete the victim pod
+type deletePod struct {
+	client kubernetes.Interface
+}
+func (s *deletePod) ApplyChaos(victim v1.Pod) error {
+	return s.client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, nil)
+}
+func (s *deletePod) Name() string { return "terminate pod" }
+
+var _ ChaosAction = &deletePod{}
+
+// Execute the given command on victim pods
+type execOnPod struct {
+	client restclient.Interface
+	config *restclient.Config
+
+	containerName string
+	command []string
+}
+
+// Based on https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/exec.go
+func (s *execOnPod) ApplyChaos(pod v1.Pod) error {
+	var container string
+	if s.containerName != "" {
+		for _, c := range pod.Spec.Containers {
+			container = c.Name;
+		}
+	}
+
+	req := s.client.Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		Param("container", container)
+	req.VersionedParams(&v1.PodExecOptions{
+		Container: container,
+		Command:   s.command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(s.config, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+	// TODO: Collect stderr/stdout in RAM and log
+	err =  exec.Stream(remotecommand.StreamOptions{
+		Stdin:             nil,
+		Stdout:            os.Stdout,
+		Stderr:            os.Stderr,
+		Tty:               false,
+		TerminalSizeQueue: nil,
+	})
+
+	return err
+}
+func (s *execOnPod) Name() string { return fmt.Sprintf("exec '%v'", s.command) }
+var _ ChaosAction = &execOnPod{}

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -73,7 +73,7 @@ var (
 // * a logger implementing logrus.FieldLogger to send log output to
 // * what specific action to use to imbue chaos on victim pods
 // * whether to enable/disable event creation
-func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, action ChaosAction, createEvent bool, gracePeriod time.Duration) *Chaoskube {
+func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, action ChaosAction, createEvent bool) *Chaoskube {
 	return &Chaoskube{
 		Client:             client,
 		Labels:             labels,
@@ -87,7 +87,6 @@ func New(client kubernetes.Interface, labels, annotations, namespaces labels.Sel
 		Logger:             logger,
 		Action:             action,
 		CreateEvent:        createEvent,
-		GracePeriod:        gracePeriod,
 		Now:                time.Now,
 	}
 }

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -43,8 +43,7 @@ func (suite *Suite) TestNew() {
 		excludedTimesOfDay = []util.TimePeriod{util.TimePeriod{}}
 		excludedDaysOfYear = []time.Time{time.Now()}
 		minimumAge         = time.Duration(42)
-		action             = NewDeletePodAction(client, -1)
-		gracePeriod        = 10 * time.Second
+		action             = NewDeletePodAction(client, 10*time.Second)
 	)
 
 	chaoskube := New(
@@ -60,7 +59,6 @@ func (suite *Suite) TestNew() {
 		logger,
 		action,
 		true,
-		gracePeriod,
 	)
 	suite.Require().NotNil(chaoskube)
 
@@ -75,7 +73,6 @@ func (suite *Suite) TestNew() {
 	suite.Equal(minimumAge, chaoskube.MinimumAge)
 	suite.Equal(logger, chaoskube.Logger)
 	suite.Equal(action, chaoskube.Action)
-	suite.Equal(gracePeriod, chaoskube.GracePeriod)
 }
 
 // TestRunContextCanceled tests that a canceled context will exit the Run function.
@@ -603,7 +600,7 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 	if dryRun {
 		action = NewDryRunAction()
 	} else {
-		action = NewDeletePodAction(client, -1)
+		action = NewDeletePodAction(client, gracePeriod)
 	}
 
 	return New(
@@ -619,7 +616,6 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 		logger,
 		action,
 		createEvent,
-		gracePeriod,
 	)
 }
 

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -218,7 +218,7 @@ func (suite *Suite) TestDeletePod() {
 
 		victim := util.NewPod("default", "foo", v1.PodRunning)
 
-		err := chaoskube.DeletePod(victim)
+		err := chaoskube.ApplyChaos(victim)
 		suite.Require().NoError(err)
 
 		suite.assertLog(log.InfoLevel, "terminating pod", log.Fields{"namespace": "default", "name": "foo"})

--- a/main.go
+++ b/main.go
@@ -191,7 +191,6 @@ func main() {
 		log.StandardLogger(),
 		action,
 		createEvent,
-		gracePeriod,
 	)
 
 	if metricsAddress != "" {


### PR DESCRIPTION
This is a proposal to introduce alternative means of killing
pods, outside of simply asking kubernetes to stop them.

Specifically, it allows executing a shell command on a victim
container; that shell command can then be a simple kill -9,
a fork bomb, or any other means of destruction.

There are, at least, two reasons why this is useful. First,
it gives an option of more realistic failures. Simply deleting
a pod is a rather kind way to stop a pod - in reality a pod is likely
to go down in flames from lack of memory, segfaulting or instant
hardware failure. This brings the chaos closer to reality.

The second reason is that this helps test operators that directly
manipulate pods, rather than rely on higher-level concepts like
StatefulSets, Deployments and so on. In this case, the thing we want
to test is the operators ability to realize a pod is severely broken,
and to take appropriate action, depending on what software the operator
is running in the failed pod.

Note: These code changes contain a TODO and no tests; I stopped when I'd verified it worked, so I wouldn't spend more effort than necessary in case this is rejected. If y'all are keen to accept this in some form, I'm super happy to polish it up and add appropriate tests. 

Let me know what you think!

Closes #103