### PR TITLE
Implement event creation after terminating a pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--timezone`              | timezone from tz database, e.g. "America/New_York", "UTC" or "Local" | (UTC)                      |
 | `--minimum-age`           | Minimum age to filter pods by                                        | 0s (matches every pod)     |
 | `--dry-run`               | don't kill pods, only log what would have been done                  | true                       |
+| `--create-events`         | If true, create an event in victims namespace after termination      | true                       |
 
 ## Related work
 

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -217,7 +217,7 @@ func (c *Chaoskube) CreateDeleteEvent(victim v1.Pod) error {
 		return err
 	}
 
-	t := metav1.Time{Time: time.Now()}
+	t := metav1.Time{Time: c.Now()}
 	_, err = c.Client.CoreV1().Events(victim.Namespace).Create(&v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.chaos.%x", victim.Name, t.UnixNano()),

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -57,6 +57,7 @@ func (suite *Suite) TestNew() {
 		minimumAge,
 		logger,
 		false,
+		true,
 	)
 	suite.Require().NotNil(chaoskube)
 
@@ -85,6 +86,7 @@ func (suite *Suite) TestRunContextCanceled() {
 		time.UTC,
 		time.Duration(0),
 		false,
+		true,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -134,6 +136,7 @@ func (suite *Suite) TestCandidates() {
 			time.UTC,
 			time.Duration(0),
 			false,
+			true,
 		)
 
 		suite.assertCandidates(chaoskube, tt.pods)
@@ -168,6 +171,7 @@ func (suite *Suite) TestVictim() {
 			time.UTC,
 			time.Duration(0),
 			false,
+			true,
 		)
 
 		suite.assertVictim(chaoskube, tt.victim)
@@ -186,6 +190,7 @@ func (suite *Suite) TestNoVictimReturnsError() {
 		time.UTC,
 		time.Duration(0),
 		false,
+		true,
 	)
 
 	_, err := chaoskube.Victim()
@@ -214,6 +219,7 @@ func (suite *Suite) TestDeletePod() {
 			time.UTC,
 			time.Duration(0),
 			tt.dryRun,
+			true,
 		)
 
 		victim := util.NewPod("default", "foo", v1.PodRunning)
@@ -444,6 +450,7 @@ func (suite *Suite) TestTerminateVictim() {
 			tt.timezone,
 			time.Duration(0),
 			false,
+			true,
 		)
 		chaoskube.Now = tt.now
 
@@ -469,6 +476,7 @@ func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 		time.UTC,
 		time.Duration(0),
 		false,
+		true,
 	)
 
 	err := chaoskube.TerminateVictim()
@@ -517,7 +525,7 @@ func (suite *Suite) assertLog(level log.Level, msg string, fields log.Fields) {
 	}
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,
@@ -528,6 +536,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 		timezone,
 		minimumAge,
 		dryRun,
+		createEvent,
 	)
 
 	pods := []v1.Pod{
@@ -544,7 +553,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 	return chaoskube
 }
 
-func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool) *Chaoskube {
+func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool) *Chaoskube {
 	logOutput.Reset()
 
 	return New(
@@ -559,6 +568,7 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 		minimumAge,
 		logger,
 		dryRun,
+		createEvent,
 	)
 }
 
@@ -658,6 +668,7 @@ func (suite *Suite) TestMinimumAge() {
 			time.UTC,
 			tt.minimumAge,
 			false,
+			true,
 		)
 		chaoskube.Now = tt.now
 

--- a/examples/rbac.yaml
+++ b/examples/rbac.yaml
@@ -6,9 +6,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["list", "delete"]
-
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ var (
 	kubeconfig         string
 	interval           time.Duration
 	dryRun             bool
+	createEvent        bool
 	debug              bool
 	metricsAddress     string
 )
@@ -59,6 +60,7 @@ func init() {
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").StringVar(&kubeconfig)
 	kingpin.Flag("interval", "Interval between Pod terminations").Default("10m").DurationVar(&interval)
 	kingpin.Flag("dry-run", "If true, don't actually do anything.").Default("true").BoolVar(&dryRun)
+	kingpin.Flag("create-events", "If true, create an event in victims namespace after termination.").Default("true").BoolVar(&createEvent)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&debug)
 	kingpin.Flag("metrics-address", "Listening address for metrics handler").Default(":8080").StringVar(&metricsAddress)
 }
@@ -86,6 +88,7 @@ func main() {
 		"dryRun":             dryRun,
 		"debug":              debug,
 		"metricsAddress":     metricsAddress,
+		"createEvent":        createEvent,
 	}).Debug("reading config")
 
 	log.WithFields(log.Fields{
@@ -161,6 +164,7 @@ func main() {
 		minimumAge,
 		log.StandardLogger(),
 		dryRun,
+		createEvent,
 	)
 
 	if metricsAddress != "" {

--- a/util/util.go
+++ b/util/util.go
@@ -136,6 +136,7 @@ func NewPod(namespace, name string, phase v1.PodPhase) v1.Pod {
 			Annotations: map[string]string{
 				"chaos": name,
 			},
+			SelfLink: fmt.Sprintf("/api/v1/namespaces/%s/pods/%s", namespace, name),
 		},
 		Status: v1.PodStatus{
 			Phase: phase,


### PR DESCRIPTION
Currently chaoskube logs the termination of pods only to stdout. This patch implements the creation of a Kubernetes Event in victims namespace so users which cannot access chaoskubes logs can see who terminated their pod. There is a new flag to disable this feature.

Event looks like:
```
$ kubectl get events
LAST SEEN   FIRST SEEN   COUNT     NAME                                       KIND        SUBOBJECT                      TYPE      REASON         SOURCE                            MESSAGE
56s         56s          1         calico-node-tj5pq.chaos.15543f44b237b716   Pod                                        Normal    Chaos                                            Deleted pod calico-node-tj5pq
```

RBAC rules were extended to allow this function.