### PR TITLE
Single namespace mode

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -167,8 +167,7 @@ func (c *Chaoskube) Victim() (v1.Pod, error) {
 // It returns all pods that match the configured label, annotation and namespace selectors.
 func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	listOptions := metav1.ListOptions{LabelSelector: c.Labels.String()}
-
-
+	
 	req, _ := c.Namespaces.Requirements()
 
 	var podList *v1.PodList

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -171,12 +171,6 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 
 	req, _ := c.Namespaces.Requirements()
 
-	c.Logger.WithFields(log.Fields{
-		"tostring": c.Namespaces.String(),
-		"len": len(req),
-		"rune": string([]rune(c.Namespaces.String())[0]),
-	}).Info("Testing namespace label selector")
-
 	var podList *v1.PodList
 	var err error
 	if len(req) == 1 && string([]rune(c.Namespaces.String())[0]) != "!" {


### PR DESCRIPTION
I manage several large multi-tenant clusters, one of our users wanted to use your tool in their namespace so I put together this hack. We only grant our users the ability to get/list/watch pods in their own namespace therefore this tool will error out when it tries to make a cluster-level request for pods.

I made a simple change: If there is only one namespace in the --namespaces arg and that namespace is not negated then it makes the pods query using that namespace as the context.

Thanks!

Closes https://github.com/linki/chaoskube/issues/92