### PR TITLE
feat: add grace period option to terminate pods

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -200,15 +200,7 @@ func (c *Chaoskube) DeletePod(victim v1.Pod) error {
 		return nil
 	}
 
-	var err error
-	pods := c.Client.CoreV1().Pods(victim.Namespace)
-	if c.GracePeriod >= 0 {
-		deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &c.GracePeriod}
-		err = pods.Delete(victim.Name, &deleteOptions)
-	} else {
-		err = pods.Delete(victim.Name, nil)
-	}
-
+	err := c.Client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, deleteOptions(c.GracePeriod))
 	if err != nil {
 		return err
 	}
@@ -356,4 +348,12 @@ func filterByMinimumAge(pods []v1.Pod, minimumAge time.Duration, now time.Time) 
 	}
 
 	return filteredList
+}
+
+func deleteOptions(gracePeriod int64) *metav1.DeleteOptions {
+	if gracePeriod == -1 {
+		return nil
+	}
+
+	return &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
 }

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -200,8 +200,15 @@ func (c *Chaoskube) DeletePod(victim v1.Pod) error {
 		return nil
 	}
 
-	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &c.GracePeriod}
-	err := c.Client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, &deleteOptions)
+	var err error
+	pods := c.Client.CoreV1().Pods(victim.Namespace)
+	if c.GracePeriod >= 0 {
+		deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &c.GracePeriod}
+		err = pods.Delete(victim.Name, &deleteOptions)
+	} else {
+		err = pods.Delete(victim.Name, nil)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -47,7 +47,7 @@ type Chaoskube struct {
 	// create event with deletion message in victims namespace
 	CreateEvent bool
 	// grace period to terminate the pods
-	GracePeriod int64
+	GracePeriod time.Duration
 	// a function to retrieve the current time
 	Now func() time.Time
 }
@@ -73,7 +73,7 @@ var (
 // * a logger implementing logrus.FieldLogger to send log output to
 // * whether to enable/disable dry-run mode
 // * whether to enable/disable event creation
-func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, createEvent bool, gracePeriod int64) *Chaoskube {
+func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, createEvent bool, gracePeriod time.Duration) *Chaoskube {
 	return &Chaoskube{
 		Client:             client,
 		Labels:             labels,
@@ -350,10 +350,10 @@ func filterByMinimumAge(pods []v1.Pod, minimumAge time.Duration, now time.Time) 
 	return filteredList
 }
 
-func deleteOptions(gracePeriod int64) *metav1.DeleteOptions {
-	if gracePeriod == -1 {
+func deleteOptions(gracePeriod time.Duration) *metav1.DeleteOptions {
+	if gracePeriod < 0 {
 		return nil
 	}
 
-	return &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+	return &metav1.DeleteOptions{GracePeriodSeconds: (*int64)(&gracePeriod)}
 }

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -46,6 +46,8 @@ type Chaoskube struct {
 	DryRun bool
 	// create event with deletion message in victims namespace
 	CreateEvent bool
+	// grace period to terminate the pods
+	GracePeriod int64
 	// a function to retrieve the current time
 	Now func() time.Time
 }
@@ -71,7 +73,7 @@ var (
 // * a logger implementing logrus.FieldLogger to send log output to
 // * whether to enable/disable dry-run mode
 // * whether to enable/disable event creation
-func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, createEvent bool) *Chaoskube {
+func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, createEvent bool, gracePeriod int64) *Chaoskube {
 	return &Chaoskube{
 		Client:             client,
 		Labels:             labels,
@@ -85,6 +87,7 @@ func New(client kubernetes.Interface, labels, annotations, namespaces labels.Sel
 		Logger:             logger,
 		DryRun:             dryRun,
 		CreateEvent:        createEvent,
+		GracePeriod:        gracePeriod,
 		Now:                time.Now,
 	}
 }
@@ -197,7 +200,8 @@ func (c *Chaoskube) DeletePod(victim v1.Pod) error {
 		return nil
 	}
 
-	err := c.Client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, nil)
+	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &c.GracePeriod}
+	err := c.Client.CoreV1().Pods(victim.Namespace).Delete(victim.Name, &deleteOptions)
 	if err != nil {
 		return err
 	}

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -43,6 +43,7 @@ func (suite *Suite) TestNew() {
 		excludedTimesOfDay = []util.TimePeriod{util.TimePeriod{}}
 		excludedDaysOfYear = []time.Time{time.Now()}
 		minimumAge         = time.Duration(42)
+		gracePeriod        = 10 * time.Second
 	)
 
 	chaoskube := New(
@@ -58,7 +59,7 @@ func (suite *Suite) TestNew() {
 		logger,
 		false,
 		true,
-		10,
+		gracePeriod,
 	)
 	suite.Require().NotNil(chaoskube)
 
@@ -73,7 +74,7 @@ func (suite *Suite) TestNew() {
 	suite.Equal(minimumAge, chaoskube.MinimumAge)
 	suite.Equal(logger, chaoskube.Logger)
 	suite.Equal(false, chaoskube.DryRun)
-	suite.Equal(int64(10), chaoskube.GracePeriod)
+	suite.Equal(gracePeriod, chaoskube.GracePeriod)
 }
 
 // TestRunContextCanceled tests that a canceled context will exit the Run function.
@@ -563,7 +564,7 @@ func (suite *Suite) assertLog(level log.Level, msg string, fields log.Fields) {
 	}
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod int64) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod time.Duration) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,
@@ -592,7 +593,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 	return chaoskube
 }
 
-func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod int64) *Chaoskube {
+func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod time.Duration) *Chaoskube {
 	logOutput.Reset()
 
 	return New(
@@ -729,7 +730,7 @@ func (suite *Suite) TestMinimumAge() {
 
 func (suite *Suite) TestDeleteOptions() {
 	for _, tt := range []struct {
-		gracePeriod int64
+		gracePeriod time.Duration
 		expected    *metav1.DeleteOptions
 	}{
 		{

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -58,6 +58,7 @@ func (suite *Suite) TestNew() {
 		logger,
 		false,
 		true,
+		10,
 	)
 	suite.Require().NotNil(chaoskube)
 
@@ -72,6 +73,7 @@ func (suite *Suite) TestNew() {
 	suite.Equal(minimumAge, chaoskube.MinimumAge)
 	suite.Equal(logger, chaoskube.Logger)
 	suite.Equal(false, chaoskube.DryRun)
+	suite.Equal(int64(10), chaoskube.GracePeriod)
 }
 
 // TestRunContextCanceled tests that a canceled context will exit the Run function.
@@ -87,6 +89,7 @@ func (suite *Suite) TestRunContextCanceled() {
 		time.Duration(0),
 		false,
 		true,
+		10,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -137,6 +140,7 @@ func (suite *Suite) TestCandidates() {
 			time.Duration(0),
 			false,
 			true,
+			10,
 		)
 
 		suite.assertCandidates(chaoskube, tt.pods)
@@ -172,6 +176,7 @@ func (suite *Suite) TestVictim() {
 			time.Duration(0),
 			false,
 			true,
+			10,
 		)
 
 		suite.assertVictim(chaoskube, tt.victim)
@@ -191,6 +196,7 @@ func (suite *Suite) TestNoVictimReturnsError() {
 		time.Duration(0),
 		false,
 		true,
+		10,
 	)
 
 	_, err := chaoskube.Victim()
@@ -220,6 +226,7 @@ func (suite *Suite) TestDeletePod() {
 			time.Duration(0),
 			tt.dryRun,
 			true,
+			10,
 		)
 
 		victim := util.NewPod("default", "foo", v1.PodRunning)
@@ -451,6 +458,7 @@ func (suite *Suite) TestTerminateVictim() {
 			time.Duration(0),
 			false,
 			true,
+			10,
 		)
 		chaoskube.Now = tt.now
 
@@ -476,6 +484,7 @@ func (suite *Suite) TestTerminateVictimCreatesEvent() {
 		time.Duration(0),
 		false,
 		true,
+		10,
 	)
 	chaoskube.Now = ThankGodItsFriday{}.Now
 
@@ -505,6 +514,7 @@ func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 		time.Duration(0),
 		false,
 		true,
+		10,
 	)
 
 	err := chaoskube.TerminateVictim()
@@ -553,7 +563,7 @@ func (suite *Suite) assertLog(level log.Level, msg string, fields log.Fields) {
 	}
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod int64) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,
@@ -565,6 +575,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 		minimumAge,
 		dryRun,
 		createEvent,
+		gracePeriod,
 	)
 
 	pods := []v1.Pod{
@@ -581,7 +592,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 	return chaoskube
 }
 
-func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool) *Chaoskube {
+func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod int64) *Chaoskube {
 	logOutput.Reset()
 
 	return New(
@@ -597,6 +608,7 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 		logger,
 		dryRun,
 		createEvent,
+		gracePeriod,
 	)
 }
 
@@ -697,6 +709,7 @@ func (suite *Suite) TestMinimumAge() {
 			tt.minimumAge,
 			false,
 			true,
+			10,
 		)
 		chaoskube.Now = tt.now
 

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -726,3 +726,29 @@ func (suite *Suite) TestMinimumAge() {
 		suite.Len(pods, tt.candidates)
 	}
 }
+
+func (suite *Suite) TestDeleteOptions() {
+	for _, tt := range []struct {
+		gracePeriod int64
+		expected    *metav1.DeleteOptions
+	}{
+		{
+			-1,
+			nil,
+		},
+		{
+			0,
+			&metav1.DeleteOptions{GracePeriodSeconds: int64Ptr(0)},
+		},
+		{
+			300,
+			&metav1.DeleteOptions{GracePeriodSeconds: int64Ptr(300)},
+		},
+	} {
+		suite.Equal(tt.expected, deleteOptions(tt.gracePeriod))
+	}
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -43,7 +43,7 @@ var (
 	createEvent        bool
 	debug              bool
 	metricsAddress     string
-	gracePeriod        int64
+	gracePeriod        time.Duration
 )
 
 func init() {
@@ -64,7 +64,7 @@ func init() {
 	kingpin.Flag("create-events", "If true, create an event in victims namespace after termination.").Default("true").BoolVar(&createEvent)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&debug)
 	kingpin.Flag("metrics-address", "Listening address for metrics handler").Default(":8080").StringVar(&metricsAddress)
-	kingpin.Flag("grace-period", "Grace period in seconds to terminate Pods").Default("-1").Int64Var(&gracePeriod)
+	kingpin.Flag("grace-period", "Grace period to terminate Pods. Negative values will use the Pod's grace period.").Default("-1s").DurationVar(&gracePeriod)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func init() {
 	kingpin.Flag("create-events", "If true, create an event in victims namespace after termination.").Default("true").BoolVar(&createEvent)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&debug)
 	kingpin.Flag("metrics-address", "Listening address for metrics handler").Default(":8080").StringVar(&metricsAddress)
-	kingpin.Flag("grace-period", "Grace period in seconds to terminate Pods").Default("30").Int64Var(&gracePeriod)
+	kingpin.Flag("grace-period", "Grace period in seconds to terminate Pods").Default("-1").Int64Var(&gracePeriod)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -95,10 +95,9 @@ func main() {
 	}).Debug("reading config")
 
 	log.WithFields(log.Fields{
-		"version":     version,
-		"dryRun":      dryRun,
-		"interval":    interval,
-		"gracePeriod": gracePeriod,
+		"version":  version,
+		"dryRun":   dryRun,
+		"interval": interval,
 	}).Info("starting up")
 
 	client, err := newClient()


### PR DESCRIPTION
This PR adds a `--grace-period` option to be able to follow different pod termination policies (gracefully vs non-gracefully). The default value is 30, that is the default grace period used by Kubernetes.

Related #103
Closes #80