### PR TITLE
Replace event related code with Kube's EventRecorder

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,6 +104,14 @@
   source = "github.com/kubermatic/glog-logrus"
 
 [[projects]]
+  branch = "master"
+  digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
+
+[[projects]]
   digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
   name = "github.com/golang/protobuf"
   packages = [
@@ -522,7 +530,7 @@
   revision = "6dd46049f39503a1fc8d65de4bd566829e95faff"
 
 [[projects]]
-  digest = "1:35c9aa7ecc8206c40ef7fa3184da1924e6ef884dd7ee53874e4b68e2778ca492"
+  digest = "1:805a902ddc3df1afb614d2f612a07ba16a492409531fc4a1e4c1950a63ac8cec"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -612,6 +620,7 @@
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
     "tools/metrics",
+    "tools/record",
     "tools/reference",
     "transport",
     "util/cert",
@@ -649,8 +658,10 @@
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/record",
     "k8s.io/client-go/tools/reference",
   ]
   solver-name = "gps-cdcl"

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -58,7 +58,6 @@ func (suite *Suite) TestNew() {
 		minimumAge,
 		logger,
 		false,
-		true,
 		gracePeriod,
 	)
 	suite.Require().NotNil(chaoskube)
@@ -89,7 +88,6 @@ func (suite *Suite) TestRunContextCanceled() {
 		time.UTC,
 		time.Duration(0),
 		false,
-		true,
 		10,
 	)
 
@@ -140,7 +138,6 @@ func (suite *Suite) TestCandidates() {
 			time.UTC,
 			time.Duration(0),
 			false,
-			true,
 			10,
 		)
 
@@ -176,7 +173,6 @@ func (suite *Suite) TestVictim() {
 			time.UTC,
 			time.Duration(0),
 			false,
-			true,
 			10,
 		)
 
@@ -196,7 +192,6 @@ func (suite *Suite) TestNoVictimReturnsError() {
 		time.UTC,
 		time.Duration(0),
 		false,
-		true,
 		10,
 	)
 
@@ -226,7 +221,6 @@ func (suite *Suite) TestDeletePod() {
 			time.UTC,
 			time.Duration(0),
 			tt.dryRun,
-			true,
 			10,
 		)
 
@@ -458,7 +452,6 @@ func (suite *Suite) TestTerminateVictim() {
 			tt.timezone,
 			time.Duration(0),
 			false,
-			true,
 			10,
 		)
 		chaoskube.Now = tt.now
@@ -473,35 +466,6 @@ func (suite *Suite) TestTerminateVictim() {
 	}
 }
 
-func (suite *Suite) TestTerminateVictimCreatesEvent() {
-	chaoskube := suite.setupWithPods(
-		labels.Everything(),
-		labels.Everything(),
-		labels.Everything(),
-		[]time.Weekday{},
-		[]util.TimePeriod{},
-		[]time.Time{},
-		time.UTC,
-		time.Duration(0),
-		false,
-		true,
-		10,
-	)
-	chaoskube.Now = ThankGodItsFriday{}.Now
-
-	err := chaoskube.TerminateVictim()
-	suite.Require().NoError(err)
-
-	events, err := chaoskube.Client.CoreV1().Events(v1.NamespaceAll).List(metav1.ListOptions{})
-	suite.Require().NoError(err)
-
-	suite.Require().Len(events.Items, 1)
-	event := events.Items[0]
-
-	suite.Equal("foo.chaos.-2be96689beac4e00", event.Name)
-	suite.Equal("Deleted pod foo", event.Message)
-}
-
 // TestTerminateNoVictimLogsInfo tests that missing victim prints a log message
 func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 	chaoskube := suite.setup(
@@ -514,7 +478,6 @@ func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 		time.UTC,
 		time.Duration(0),
 		false,
-		true,
 		10,
 	)
 
@@ -564,7 +527,7 @@ func (suite *Suite) assertLog(level log.Level, msg string, fields log.Fields) {
 	}
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod time.Duration) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,
@@ -575,7 +538,6 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 		timezone,
 		minimumAge,
 		dryRun,
-		createEvent,
 		gracePeriod,
 	)
 
@@ -593,7 +555,7 @@ func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations lab
 	return chaoskube
 }
 
-func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, createEvent bool, gracePeriod time.Duration) *Chaoskube {
+func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration) *Chaoskube {
 	logOutput.Reset()
 
 	return New(
@@ -608,7 +570,6 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 		minimumAge,
 		logger,
 		dryRun,
-		createEvent,
 		gracePeriod,
 	)
 }
@@ -709,7 +670,6 @@ func (suite *Suite) TestMinimumAge() {
 			time.UTC,
 			tt.minimumAge,
 			false,
-			true,
 			10,
 		)
 		chaoskube.Now = tt.now

--- a/main.go
+++ b/main.go
@@ -167,7 +167,6 @@ func main() {
 		minimumAge,
 		log.StandardLogger(),
 		dryRun,
-		createEvent,
 		gracePeriod,
 	)
 

--- a/util/util.go
+++ b/util/util.go
@@ -127,6 +127,10 @@ func TimeOfDay(pointInTime time.Time) time.Time {
 // NewPod returns a new pod instance for testing purposes.
 func NewPod(namespace, name string, phase v1.PodPhase) v1.Pod {
 	return v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,


### PR DESCRIPTION
Replaces the feature of exporting events from https://github.com/linki/chaoskube/pull/105 to use Kubernetes' EventRecorder.

With this:
* exporting events is enabled by default and cannot be turned off
* events are attached to the Pod being killed as opposed to the namespace it's in
  * `kubectl get events` can be used to show the events, see line four below.

```console
$ kubectl get events
LAST SEEN   FIRST SEEN   COUNT     NAME                                              KIND         SUBOBJECT                 TYPE      REASON             SOURCE                                            MESSAGE
2m          2m           1         tiller-deploy-557f85548b-7x9dj.156afef7a3d9f6ef   Pod                                    Normal    Scheduled          default-scheduler                                 Successfully assigned tiller/tiller-deploy-557f85548b-7x9dj to gke-kube-1-standard-2-f6b46c2f-rgdc
2m          2m           1         tiller-deploy-557f85548b.156afef7a2c8b563         ReplicaSet                             Normal    SuccessfulCreate   replicaset-controller                             Created pod: tiller-deploy-557f85548b-7x9dj
2m          2m           1         tiller-deploy-557f85548b-g959l.156afef79c8e201e   Pod                                    Normal    Killing            chaoskube                                         Pod was deleted by chaoskube to introduce chaos.
2m          2m           1         tiller-deploy-557f85548b-g959l.156afef7ae0fa311   Pod          spec.containers{tiller}   Normal    Killing            kubelet, gke-kube-1-preemptible-1-00495950-m0rn   Killing container with id containerd://tiller:Need to kill Pod
2m          2m           1         tiller-deploy-557f85548b-7x9dj.156afef7c9b8e373   Pod          spec.containers{tiller}   Normal    Pulling            kubelet, gke-kube-1-standard-2-f6b46c2f-rgdc      pulling image "gcr.io/kubernetes-helm/tiller:v2.11.0"
2m          2m           1         tiller-deploy-557f85548b-7x9dj.156afef8baf24730   Pod          spec.containers{tiller}   Normal    Pulled             kubelet, gke-kube-1-standard-2-f6b46c2f-rgdc      Successfully pulled image "gcr.io/kubernetes-helm/tiller:v2.11.0"
2m          2m           1         tiller-deploy-557f85548b-7x9dj.156afef8bd854438   Pod          spec.containers{tiller}   Normal    Created            kubelet, gke-kube-1-standard-2-f6b46c2f-rgdc      Created container
2m          2m           1         tiller-deploy-557f85548b-7x9dj.156afef93f11e4ec   Pod          spec.containers{tiller}   Normal    Started            kubelet, gke-kube-1-standard-2-f6b46c2f-rgdc      Started container
```