### PR TITLE
Add include/exclude filters for pod names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.14.0 - 2019-05-20
+
+  Features:
+  * [#121](https://github.com/linki/chaoskube/pull/121) Add include and exclude regular expression filters for pod names @dansimone
+
 ## v0.13.0 - 2019-01-30
 
   Features:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ spec:
         - --annotations=chaos.alpha.kubernetes.io/enabled=true
         # exclude all pods in the kube-system namespace
         - --namespaces=!kube-system
+        # include all pods whose names match a certain pattern
+        - --include-pattern=
+        # exclude all pods whose names match a certain pattern
+        - --exclude-pattern=
         # don't kill anything on weekends
         - --excluded-weekdays=Sat,Sun
         # don't kill anything during the night or at lunchtime
@@ -104,7 +108,7 @@ Remember that `chaoskube` by default kills any pod in all your namespaces, inclu
 
 ## Filtering targets
 
-However, you can limit the search space of `chaoskube` by providing label, annotation and namespace selectors as well as a minimum age setting.
+However, you can limit the search space of `chaoskube` by providing label, annotation, and namespace selectors, pod name include/exclude patterns, as well as a minimum age setting.
 
 ```console
 $ chaoskube --labels 'app=mate,chaos,stage!=production'
@@ -123,6 +127,16 @@ INFO[0000] setting pod filter       namespaces="default,staging,testing"
 ```
 
 This will filter for pods in the three namespaces `default`, `staging` and `testing`.
+
+You can filter pods by name:
+
+```console
+$ chaoskube --include-pattern 'foo|bar' --exclude-pattern 'prod'
+...
+INFO[0000] setting pod filter       excludePattern="prod" includePattern="foo|bar"
+```
+
+This will cause only pods whose name contains 'foo' or 'bar' and does _not_ contain 'prod' to be targeted.
 
 You can also exclude namespaces and mix and match with the label and annotation selectors.
 
@@ -199,6 +213,8 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--labels`                | label selector to filter pods by                                     | (matches everything)       |
 | `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
+| `--include-pattern`       | regex pattern for pod names to include                               | (all included  )           |
+| `--exclude-pattern`       | regex pattern for pod names to exclude                               | (none excluded )           |
 | `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |
 | `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "22:00-08:00"       | (no times of day excluded) |
 | `--excluded-days-of-year` | days of a year when chaos is to be suspended, e.g. "Apr1,Dec24"      | (no days of year excluded) |

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ spec:
         # exclude all pods in the kube-system namespace
         - --namespaces=!kube-system
         # include all pods whose names match a certain pattern
-        - --include-pattern=
+        - --included-pod-names=foo|bar
         # exclude all pods whose names match a certain pattern
-        - --exclude-pattern=
+        - --excluded-pod-names=prod
         # don't kill anything on weekends
         - --excluded-weekdays=Sat,Sun
         # don't kill anything during the night or at lunchtime
@@ -131,9 +131,9 @@ This will filter for pods in the three namespaces `default`, `staging` and `test
 You can filter pods by name:
 
 ```console
-$ chaoskube --include-pattern 'foo|bar' --exclude-pattern 'prod'
+$ chaoskube --included-pod-names 'foo|bar' --excluded-pod-names 'prod'
 ...
-INFO[0000] setting pod filter       excludePattern="prod" includePattern="foo|bar"
+INFO[0000] setting pod filter       excludedPodNames="prod" includedPodNames="foo|bar"
 ```
 
 This will cause only pods whose name contains 'foo' or 'bar' and does _not_ contain 'prod' to be targeted.
@@ -213,8 +213,8 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--labels`                | label selector to filter pods by                                     | (matches everything)       |
 | `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
-| `--include-pattern`       | regex pattern for pod names to include                               | (all included)             |
-| `--exclude-pattern`       | regex pattern for pod names to exclude                               | (none excluded)            |
+| `--included-pod-names`    | regex pattern for pod names to include                               | (all included)             |
+| `--excluded-pod-names`    | regex pattern for pod names to exclude                               | (none excluded)            |
 | `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |
 | `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "22:00-08:00"       | (no times of day excluded) |
 | `--excluded-days-of-year` | days of a year when chaos is to be suspended, e.g. "Apr1,Dec24"      | (no days of year excluded) |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can filter pods by name:
 ```console
 $ chaoskube --included-pod-names 'foo|bar' --excluded-pod-names 'prod'
 ...
-INFO[0000] setting pod filter       excludedPodNames="prod" includedPodNames="foo|bar"
+INFO[0000] setting pod filter       excludedPodNames=prod includedPodNames="foo|bar"
 ```
 
 This will cause only pods whose name contains 'foo' or 'bar' and does _not_ contain 'prod' to be targeted.
@@ -213,8 +213,8 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--labels`                | label selector to filter pods by                                     | (matches everything)       |
 | `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
-| `--included-pod-names`    | regex pattern for pod names to include                               | (all included)             |
-| `--excluded-pod-names`    | regex pattern for pod names to exclude                               | (none excluded)            |
+| `--included-pod-names`    | regular expression pattern for pod names to include                  | (all included)             |
+| `--excluded-pod-names`    | regular expression pattern for pod names to exclude                  | (none excluded)            |
 | `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |
 | `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "22:00-08:00"       | (no times of day excluded) |
 | `--excluded-days-of-year` | days of a year when chaos is to be suspended, e.g. "Apr1,Dec24"      | (no days of year excluded) |

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--labels`                | label selector to filter pods by                                     | (matches everything)       |
 | `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
-| `--include-pattern`       | regex pattern for pod names to include                               | (all included  )           |
-| `--exclude-pattern`       | regex pattern for pod names to exclude                               | (none excluded )           |
+| `--include-pattern`       | regex pattern for pod names to include                               | (all included)             |
+| `--exclude-pattern`       | regex pattern for pod names to exclude                               | (none excluded)            |
 | `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |
 | `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "22:00-08:00"       | (no times of day excluded) |
 | `--excluded-days-of-year` | days of a year when chaos is to be suspended, e.g. "Apr1,Dec24"      | (no days of year excluded) |

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -23,7 +23,6 @@ import (
 	"github.com/linki/chaoskube/terminator"
 	"github.com/linki/chaoskube/util"
 	"regexp"
-	"strconv"
 )
 
 // Chaoskube represents an instance of chaoskube
@@ -204,12 +203,10 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	pods = filterByAnnotations(pods, c.Annotations)
 	pods = filterByPhase(pods, v1.PodRunning)
 	pods = filterByMinimumAge(pods, c.MinimumAge, c.Now())
-	fmt.Println("BEFORE " + strconv.Itoa(len(pods)))
 	if c.IncludeRegex != nil {
 		fmt.Println(c.IncludeRegex.String())
 	}
 	pods = filterByPodName(pods, c.IncludeRegex, c.ExcludeRegex)
-	fmt.Println("AFTER " + strconv.Itoa(len(pods)))
 	return pods, nil
 }
 

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -22,6 +22,8 @@ import (
 	"github.com/linki/chaoskube/metrics"
 	"github.com/linki/chaoskube/terminator"
 	"github.com/linki/chaoskube/util"
+	"regexp"
+	"strconv"
 )
 
 // Chaoskube represents an instance of chaoskube
@@ -34,6 +36,10 @@ type Chaoskube struct {
 	Annotations labels.Selector
 	// a namespace selector which restricts the pods to choose from
 	Namespaces labels.Selector
+	// a regex for pod names to include
+	IncludeRegex *regexp.Regexp
+	// a regex for pod names to exclude
+	ExcludeRegex *regexp.Regexp
 	// a list of weekdays when termination is suspended
 	ExcludedWeekdays []time.Weekday
 	// a list of time periods of a day when termination is suspended
@@ -79,7 +85,7 @@ var (
 // * a logger implementing logrus.FieldLogger to send log output to
 // * what specific terminator to use to imbue chaos on victim pods
 // * whether to enable/disable dry-run mode
-func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, terminator terminator.Terminator) *Chaoskube {
+func New(client kubernetes.Interface, labels, annotations, namespaces labels.Selector, includeRegex, excludeRegex *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, terminator terminator.Terminator) *Chaoskube {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: client.CoreV1().Events(v1.NamespaceAll)})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "chaoskube"})
@@ -89,6 +95,8 @@ func New(client kubernetes.Interface, labels, annotations, namespaces labels.Sel
 		Labels:             labels,
 		Annotations:        annotations,
 		Namespaces:         namespaces,
+		IncludeRegex:       includeRegex,
+		ExcludeRegex:       excludeRegex,
 		ExcludedWeekdays:   excludedWeekdays,
 		ExcludedTimesOfDay: excludedTimesOfDay,
 		ExcludedDaysOfYear: excludedDaysOfYear,
@@ -196,7 +204,12 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	pods = filterByAnnotations(pods, c.Annotations)
 	pods = filterByPhase(pods, v1.PodRunning)
 	pods = filterByMinimumAge(pods, c.MinimumAge, c.Now())
-
+	fmt.Println("BEFORE " + strconv.Itoa(len(pods)))
+	if c.IncludeRegex != nil {
+		fmt.Println(c.IncludeRegex.String())
+	}
+	pods = filterByPodName(pods, c.IncludeRegex, c.ExcludeRegex)
+	fmt.Println("AFTER " + strconv.Itoa(len(pods)))
 	return pods, nil
 }
 
@@ -336,6 +349,22 @@ func filterByMinimumAge(pods []v1.Pod, minimumAge time.Duration, now time.Time) 
 
 	for _, pod := range pods {
 		if pod.ObjectMeta.CreationTimestamp.Time.Before(creationTime) {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList
+}
+
+// filterByPodName filters pods by name.  Only pods matching the includeRegex and not
+// matching the excludeRegex are returned
+func filterByPodName(pods []v1.Pod, includeRegex, excludeRegex *regexp.Regexp) []v1.Pod {
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		include := includeRegex == nil || includeRegex.String() == "" || includeRegex.MatchString(pod.Name)
+		exclude := excludeRegex != nil && excludeRegex.String() != "" && excludeRegex.MatchString(pod.Name)
+		if include && !exclude {
 			filteredList = append(filteredList, pod)
 		}
 	}

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -354,7 +354,7 @@ func filterByMinimumAge(pods []v1.Pod, minimumAge time.Duration, now time.Time) 
 // filterByPodName filters pods by name.  Only pods matching the includedPodNames and not
 // matching the excludedPodNames are returned
 func filterByPodName(pods []v1.Pod, includedPodNames, excludedPodNames *regexp.Regexp) []v1.Pod {
-	// early return optimization
+	// return early if neither included nor excluded regular expressions are given
 	if includedPodNames == nil && excludedPodNames == nil {
 		return pods
 	}

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -38,18 +38,18 @@ func (suite *Suite) SetupTest() {
 // TestNew tests that arguments are passed to the new instance correctly
 func (suite *Suite) TestNew() {
 	var (
-		client              = fake.NewSimpleClientset()
-		labelSelector, _    = labels.Parse("foo=bar")
-		annotations, _      = labels.Parse("baz=waldo")
-		namespaces, _       = labels.Parse("qux")
-		includedPodNames, _ = regexp.Compile("foo")
-		excludedPodNames, _ = regexp.Compile("bar")
-		excludedWeekdays    = []time.Weekday{time.Friday}
-		excludedTimesOfDay  = []util.TimePeriod{util.TimePeriod{}}
-		excludedDaysOfYear  = []time.Time{time.Now()}
-		minimumAge          = time.Duration(42)
-		dryRun              = true
-		terminator          = terminator.NewDeletePodTerminator(client, logger, 10*time.Second)
+		client             = fake.NewSimpleClientset()
+		labelSelector, _   = labels.Parse("foo=bar")
+		annotations, _     = labels.Parse("baz=waldo")
+		namespaces, _      = labels.Parse("qux")
+		includedPodNames   = regexp.MustCompile("foo")
+		excludedPodNames   = regexp.MustCompile("bar")
+		excludedWeekdays   = []time.Weekday{time.Friday}
+		excludedTimesOfDay = []util.TimePeriod{util.TimePeriod{}}
+		excludedDaysOfYear = []time.Time{time.Now()}
+		minimumAge         = time.Duration(42)
+		dryRun             = true
+		terminator         = terminator.NewDeletePodTerminator(client, logger, 10*time.Second)
 	)
 
 	chaoskube := New(
@@ -160,8 +160,9 @@ func (suite *Suite) TestCandidates() {
 	}
 }
 
-// TestCandidates tests that the various pod filters are applied correctly.
-func (suite *Suite) TestCandidateNamesRegexp() {
+// TestCandidatesPodNameRegexp tests that the included and excluded pod name regular expressions
+// are applied correctly.
+func (suite *Suite) TestCandidatesPodNameRegexp() {
 	foo := map[string]string{"namespace": "default", "name": "foo"}
 	bar := map[string]string{"namespace": "testing", "name": "bar"}
 
@@ -170,16 +171,15 @@ func (suite *Suite) TestCandidateNamesRegexp() {
 		excludedPodNames *regexp.Regexp
 		pods             []map[string]string
 	}{
+		// no included nor excluded regular expressions given
 		{nil, nil, []map[string]string{foo, bar}},
-
+		// either included or excluded regular expression given
 		{regexp.MustCompile("fo.*"), nil, []map[string]string{foo}},
 		{nil, regexp.MustCompile("fo.*"), []map[string]string{bar}},
-
+		// either included or excluded regular expression is empty
 		{regexp.MustCompile("fo.*"), regexp.MustCompile(""), []map[string]string{foo}},
 		{regexp.MustCompile(""), regexp.MustCompile("fo.*"), []map[string]string{bar}},
-		{regexp.MustCompile("ba.*"), regexp.MustCompile(""), []map[string]string{bar}},
-		{regexp.MustCompile(""), regexp.MustCompile("ba.*"), []map[string]string{foo}},
-
+		// both included and excluded regular expressions are considered
 		{regexp.MustCompile("fo.*"), regexp.MustCompile("f.*"), []map[string]string{}},
 	} {
 		chaoskube := suite.setupWithPods(
@@ -594,13 +594,13 @@ func (suite *Suite) assertVictim(chaoskube *Chaoskube, expected map[string]strin
 	suite.AssertPod(victim, expected)
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, includedPodNames *regexp.Regexp, exludePattern *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, includedPodNames *regexp.Regexp, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,
 		namespaces,
 		includedPodNames,
-		exludePattern,
+		excludedPodNames,
 		excludedWeekdays,
 		excludedTimesOfDay,
 		excludedDaysOfYear,

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 	"syscall"
 	"time"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/linki/chaoskube/chaoskube"
 	"github.com/linki/chaoskube/terminator"
 	"github.com/linki/chaoskube/util"
-	"regexp"
 )
 
 var (
@@ -33,8 +33,8 @@ var (
 	labelString        string
 	annString          string
 	nsString           string
-	includePattern     string
-	excludePattern     string
+	includedPodNames   *regexp.Regexp
+	excludedPodNames   *regexp.Regexp
 	excludedWeekdays   string
 	excludedTimesOfDay string
 	excludedDaysOfYear string
@@ -56,8 +56,8 @@ func init() {
 	kingpin.Flag("labels", "A set of labels to restrict the list of affected pods. Defaults to everything.").StringVar(&labelString)
 	kingpin.Flag("annotations", "A set of annotations to restrict the list of affected pods. Defaults to everything.").StringVar(&annString)
 	kingpin.Flag("namespaces", "A set of namespaces to restrict the list of affected pods. Defaults to everything.").StringVar(&nsString)
-	kingpin.Flag("include-pattern", "Regex pattern for pod names to include.  All included by default").StringVar(&includePattern)
-	kingpin.Flag("exclude-pattern", "Regex pattern for pod names to exclude.  None excluded by default").StringVar(&excludePattern)
+	kingpin.Flag("included-pod-names", "Regular expression that defines which pods to include. All included by default.").RegexpVar(&includedPodNames)
+	kingpin.Flag("excluded-pod-names", "Regular expression that defines which pods to exclude. None excluded by default.").RegexpVar(&excludedPodNames)
 	kingpin.Flag("excluded-weekdays", "A list of weekdays when termination is suspended, e.g. Sat,Sun").StringVar(&excludedWeekdays)
 	kingpin.Flag("excluded-times-of-day", "A list of time periods of a day when termination is suspended, e.g. 22:00-08:00").StringVar(&excludedTimesOfDay)
 	kingpin.Flag("excluded-days-of-year", "A list of days of a year when termination is suspended, e.g. Apr1,Dec24").StringVar(&excludedDaysOfYear)
@@ -89,8 +89,8 @@ func main() {
 		"labels":             labelString,
 		"annotations":        annString,
 		"namespaces":         nsString,
-		"includePattern":     includePattern,
-		"excludePattern":     excludePattern,
+		"includedPodNames":   includedPodNames,
+		"excludedPodNames":   excludedPodNames,
 		"excludedWeekdays":   excludedWeekdays,
 		"excludedTimesOfDay": excludedTimesOfDay,
 		"excludedDaysOfYear": excludedDaysOfYear,
@@ -121,17 +121,15 @@ func main() {
 		labelSelector = parseSelector(labelString)
 		annotations   = parseSelector(annString)
 		namespaces    = parseSelector(nsString)
-		includeRegex  = parseRegex(includePattern)
-		excludeRegex  = parseRegex(excludePattern)
 	)
 
 	log.WithFields(log.Fields{
-		"labels":         labelSelector,
-		"annotations":    annotations,
-		"includePattern": includePattern,
-		"excludePattern": excludePattern,
-		"namespaces":     namespaces,
-		"minimumAge":     minimumAge,
+		"labels":           labelSelector,
+		"annotations":      annotations,
+		"namespaces":       namespaces,
+		"includedPodNames": includedPodNames,
+		"excludedPodNames": excludedPodNames,
+		"minimumAge":       minimumAge,
 	}).Info("setting pod filter")
 
 	parsedWeekdays := util.ParseWeekdays(excludedWeekdays)
@@ -176,8 +174,8 @@ func main() {
 		labelSelector,
 		annotations,
 		namespaces,
-		includeRegex,
-		excludeRegex,
+		includedPodNames,
+		excludedPodNames,
 		parsedWeekdays,
 		parsedTimesOfDay,
 		parsedDaysOfYear,
@@ -274,17 +272,6 @@ func parseSelector(str string) labels.Selector {
 		}).Fatal("failed to parse selector")
 	}
 	return selector
-}
-
-func parseRegex(str string) *regexp.Regexp {
-	regex, err := regexp.Compile(str)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"regex": str,
-			"err":   err,
-		}).Fatal("failed to parse regex")
-	}
-	return regex
 }
 
 func formatDays(days []time.Time) []string {


### PR DESCRIPTION
This PR adds parameters that allow pod to be filtered in/out by pod name.  This is a useful feature because some existing Kubernetes applications (the one I work on is an example) don't have the necessary labels that are required to make use of the existing chaoskube label selector filtering.  So for those users, this just allows them to provide a simple regex pattern for pod names to include and to exclude.

Also includes:
- README updates to indicate the new usage
- Necessary test updates, including verifying the new capability in TestCandidates().