### PR TITLE
Allow to filter pods by namespace label selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ INFO[0000] setting pod filter       namespaces="default,staging,testing"
 
 This will filter for pods in the three namespaces `default`, `staging` and `testing`.
 
+Namespaces can additionally be filtered by a namespace label selector.
+
+```console
+$ chaoskube --namespace-labels='!integration'
+...
+INFO[0000] setting pod filter       namespaceLabels="!integration"
+```
+
+This will exclude all pods from namespaces with the label `integration`.
+
 You can filter pods by name:
 
 ```console
@@ -213,6 +223,7 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--labels`                | label selector to filter pods by                                     | (matches everything)       |
 | `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
+| `--namespace-labels`      | label selector to filter namespaces and its pods by                  | (all namespaces)           |
 | `--included-pod-names`    | regular expression pattern for pod names to include                  | (all included)             |
 | `--excluded-pod-names`    | regular expression pattern for pod names to exclude                  | (none excluded)            |
 | `--excluded-weekdays`     | weekdays when chaos is to be suspended, e.g. "Sat,Sun"               | (no weekday excluded)      |

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var (
 	labelString        string
 	annString          string
 	nsString           string
+	nsLabelString      string
 	includedPodNames   *regexp.Regexp
 	excludedPodNames   *regexp.Regexp
 	excludedWeekdays   string
@@ -59,6 +60,7 @@ func init() {
 	kingpin.Flag("labels", "A set of labels to restrict the list of affected pods. Defaults to everything.").StringVar(&labelString)
 	kingpin.Flag("annotations", "A set of annotations to restrict the list of affected pods. Defaults to everything.").StringVar(&annString)
 	kingpin.Flag("namespaces", "A set of namespaces to restrict the list of affected pods. Defaults to everything.").StringVar(&nsString)
+	kingpin.Flag("namespace-labels", "A set of labels to restrict the list of affected namespaces. Defaults to everything.").StringVar(&nsLabelString)
 	kingpin.Flag("included-pod-names", "Regular expression that defines which pods to include. All included by default.").RegexpVar(&includedPodNames)
 	kingpin.Flag("excluded-pod-names", "Regular expression that defines which pods to exclude. None excluded by default.").RegexpVar(&excludedPodNames)
 	kingpin.Flag("excluded-weekdays", "A list of weekdays when termination is suspended, e.g. Sat,Sun").StringVar(&excludedWeekdays)
@@ -98,6 +100,7 @@ func main() {
 		"labels":             labelString,
 		"annotations":        annString,
 		"namespaces":         nsString,
+		"namespaceLabels":    nsLabelString,
 		"includedPodNames":   includedPodNames,
 		"excludedPodNames":   excludedPodNames,
 		"excludedWeekdays":   excludedWeekdays,
@@ -127,15 +130,17 @@ func main() {
 	}
 
 	var (
-		labelSelector = parseSelector(labelString)
-		annotations   = parseSelector(annString)
-		namespaces    = parseSelector(nsString)
+		labelSelector   = parseSelector(labelString)
+		annotations     = parseSelector(annString)
+		namespaces      = parseSelector(nsString)
+		namespaceLabels = parseSelector(nsLabelString)
 	)
 
 	log.WithFields(log.Fields{
 		"labels":           labelSelector,
 		"annotations":      annotations,
 		"namespaces":       namespaces,
+		"namespaceLabels":  namespaceLabels,
 		"includedPodNames": includedPodNames,
 		"excludedPodNames": excludedPodNames,
 		"minimumAge":       minimumAge,
@@ -183,6 +188,7 @@ func main() {
 		labelSelector,
 		annotations,
 		namespaces,
+		namespaceLabels,
 		includedPodNames,
 		excludedPodNames,
 		parsedWeekdays,

--- a/util/util.go
+++ b/util/util.go
@@ -156,3 +156,15 @@ func NewPod(namespace, name string, phase v1.PodPhase) v1.Pod {
 		},
 	}
 }
+
+// NewNamespace returns a new namespace instance for testing purposes.
+func NewNamespace(name string) v1.Namespace {
+	return v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"env": name,
+			},
+		},
+	}
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -387,6 +387,19 @@ func (suite *Suite) TestFormatDays() {
 	}
 }
 
+func (suite *Suite) TestNewPod() {
+	pod := NewPod("namespace", "name", "phase")
+
+	suite.Equal("v1", pod.APIVersion)
+	suite.Equal("Pod", pod.Kind)
+	suite.Equal("namespace", pod.Namespace)
+	suite.Equal("name", pod.Name)
+	suite.Equal("name", pod.Labels["app"])
+	suite.Equal("name", pod.Annotations["chaos"])
+	suite.Equal("/api/v1/namespaces/namespace/pods/name", pod.SelfLink)
+	suite.EqualValues("phase", pod.Status.Phase)
+}
+
 func (suite *Suite) TestNewNamespace() {
 	namespace := NewNamespace("name")
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -387,6 +387,13 @@ func (suite *Suite) TestFormatDays() {
 	}
 }
 
+func (suite *Suite) TestNewNamespace() {
+	namespace := NewNamespace("name")
+
+	suite.Equal("name", namespace.Name)
+	suite.Equal("name", namespace.Labels["env"])
+}
+
 func TestSuite(t *testing.T) {
 	suite.Run(t, new(Suite))
 }


### PR DESCRIPTION
Allows to provide a label selector for namespaces. This can be used to limit chaoskube's action to all namespaces that match a certain label selector.

Based on https://github.com/linki/chaoskube/pull/46 and https://github.com/swestcott/chaoskube/pull/1 and rebased on master.

Thanks @swestcott for the initial work.

Implements https://github.com/linki/chaoskube/issues/44
Replaces  https://github.com/linki/chaoskube/pull/46 and https://github.com/swestcott/chaoskube/pull/1