### PR TITLE
Add filter to remove deleted pods

### DIFF
--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
@@ -829,4 +829,18 @@ func (suite *Suite) TestMinimumAge() {
 
 		suite.Len(pods, tt.candidates)
 	}
+}
+
+func (suite *Suite) TestFilterDeletedPods() {
+	deletedPod := util.NewPod("default", "deleted", v1.PodRunning)
+	now := metav1.NewTime(time.Now())
+	deletedPod.SetDeletionTimestamp(&now)
+
+	runningPod := util.NewPod("default", "running", v1.PodRunning)
+
+	pods := []v1.Pod{runningPod, deletedPod}
+
+	filtered := filterDeletedPods(pods)
+	suite.Equal(len(filtered), 1)
+	suite.Equal(pods[0].Name, "running")
 }


### PR DESCRIPTION
The `filterByPhase` function:

```
// filterByPhase filters a list of pods by a given PodPhase, e.g. Running.
func filterByPhase(pods []v1.Pod, phase v1.PodPhase) []v1.Pod {
	filteredList := []v1.Pod{}

	for _, pod := range pods {
		if pod.Status.Phase == phase {
			filteredList = append(filteredList, pod)
		}
	}

	return filteredList
}
```

does not filter out lingering pods in "terminating state", which is not a real PodPhase, but a state computed from the presence of a `DeletionTimestamp`: https://sourcegraph.com/github.com/kubernetes/kubernetes@v1.12.7/-/blob/pkg/printers/internalversion/printers.go#L640-642

Any lingering pod in this state keeps on being selected by ChaosKube for termination.
If it is fair to assume that filtering by phase was meant to only select _active_ pods and that deleted pods should not be included, this PR should address the issue.

