### PR TITLE
Adds support for terminating multiple pods per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+  * [#154](https://github.com/linki/chaoskube/pull/154) Add support for terminating multiple pods per iteration @pims
   * [#153](https://github.com/linki/chaoskube/pull/153) Don't attempt to terminate `Terminating` pods @pims
 
 ## v0.14.0 - 2019-05-20

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"regexp"
 	"time"
 
@@ -180,25 +179,6 @@ func (c *Chaoskube) TerminateVictims() error {
 	}
 
 	return result.ErrorOrNil()
-}
-
-// Victim returns a random pod from the list of Candidates.
-// It returns an error if there are no candidates to choose from.
-func (c *Chaoskube) Victim() (v1.Pod, error) {
-	pods, err := c.Candidates()
-	if err != nil {
-		return v1.Pod{}, err
-	}
-
-	c.Logger.WithField("count", len(pods)).Debug("found candidates")
-
-	if len(pods) == 0 {
-		return v1.Pod{}, errPodNotFound
-	}
-
-	index := rand.Intn(len(pods))
-
-	return pods[index], nil
 }
 
 // Victims returns up to N pods as configured by MaxKill flag

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -136,7 +136,7 @@ func (c *Chaoskube) Run(ctx context.Context, next <-chan time.Time) {
 	}
 }
 
-// TerminateVictim picks and deletes a victim.
+// TerminateVictims picks and deletes a victim.
 // It respects the configured excluded weekdays, times of day and days of a year filters.
 func (c *Chaoskube) TerminateVictims() error {
 	now := c.Now().In(c.Timezone)
@@ -192,7 +192,7 @@ func (c *Chaoskube) Victims() ([]v1.Pod, error) {
 		return []v1.Pod{}, errPodNotFound
 	}
 
-	pods = util.PodSubSlice(pods, c.MaxKill)
+	pods = util.RandomPodSubSlice(pods, c.MaxKill)
 
 	c.Logger.WithField("count", len(pods)).Debug("found victims")
 	return pods, nil

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -8,12 +8,15 @@ import (
 	"regexp"
 	"time"
 
+	multierror "github.com/hashicorp/go-multierror"
+
 	log "github.com/sirupsen/logrus"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -63,6 +66,8 @@ type Chaoskube struct {
 	EventRecorder record.EventRecorder
 	// a function to retrieve the current time
 	Now func() time.Time
+
+	MaxKill int
 }
 
 var (
@@ -86,7 +91,7 @@ var (
 // * a logger implementing logrus.FieldLogger to send log output to
 // * what specific terminator to use to imbue chaos on victim pods
 // * whether to enable/disable dry-run mode
-func New(client kubernetes.Interface, labels, annotations, namespaces, namespaceLabels labels.Selector, includedPodNames, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, terminator terminator.Terminator) *Chaoskube {
+func New(client kubernetes.Interface, labels, annotations, namespaces, namespaceLabels labels.Selector, includedPodNames, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, terminator terminator.Terminator, maxKill int) *Chaoskube {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: client.CoreV1().Events(v1.NamespaceAll)})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "chaoskube"})
@@ -109,6 +114,7 @@ func New(client kubernetes.Interface, labels, annotations, namespaces, namespace
 		Terminator:         terminator,
 		EventRecorder:      recorder,
 		Now:                time.Now,
+		MaxKill:            maxKill,
 	}
 }
 
@@ -116,7 +122,7 @@ func New(client kubernetes.Interface, labels, annotations, namespaces, namespace
 // described by channel next. It returns when the given context is canceled.
 func (c *Chaoskube) Run(ctx context.Context, next <-chan time.Time) {
 	for {
-		if err := c.TerminateVictim(); err != nil {
+		if err := c.TerminateVictims(); err != nil {
 			c.Logger.WithField("err", err).Error("failed to terminate victim")
 			metrics.ErrorsTotal.Inc()
 		}
@@ -133,7 +139,7 @@ func (c *Chaoskube) Run(ctx context.Context, next <-chan time.Time) {
 
 // TerminateVictim picks and deletes a victim.
 // It respects the configured excluded weekdays, times of day and days of a year filters.
-func (c *Chaoskube) TerminateVictim() error {
+func (c *Chaoskube) TerminateVictims() error {
 	now := c.Now().In(c.Timezone)
 
 	for _, wd := range c.ExcludedWeekdays {
@@ -157,7 +163,7 @@ func (c *Chaoskube) TerminateVictim() error {
 		}
 	}
 
-	victim, err := c.Victim()
+	victims, err := c.Victims()
 	if err == errPodNotFound {
 		c.Logger.Debug(msgVictimNotFound)
 		return nil
@@ -166,7 +172,14 @@ func (c *Chaoskube) TerminateVictim() error {
 		return err
 	}
 
-	return c.DeletePod(victim)
+	var result *multierror.Error
+	for _, victim := range victims {
+		err = c.DeletePod(victim)
+		result = multierror.Append(result, err)
+
+	}
+
+	return result.ErrorOrNil()
 }
 
 // Victim returns a random pod from the list of Candidates.
@@ -186,6 +199,23 @@ func (c *Chaoskube) Victim() (v1.Pod, error) {
 	index := rand.Intn(len(pods))
 
 	return pods[index], nil
+}
+
+// Victims returns up to N pods as configured by MaxKill flag
+func (c *Chaoskube) Victims() ([]v1.Pod, error) {
+	pods, err := c.Candidates()
+	if err != nil {
+		return []v1.Pod{}, err
+	}
+
+	if len(pods) == 0 {
+		return []v1.Pod{}, errPodNotFound
+	}
+
+	pods = util.PodSubSlice(pods, c.MaxKill)
+
+	c.Logger.WithField("count", len(pods)).Debug("found victims")
+	return pods, nil
 }
 
 // Candidates returns the list of pods that are available for termination.
@@ -213,6 +243,7 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 	pods = filterTerminatingPods(pods)
 	pods = filterByMinimumAge(pods, c.MinimumAge, c.Now())
 	pods = filterByPodName(pods, c.IncludedPodNames, c.ExcludedPodNames)
+	pods = filterByOwnerReference(pods)
 
 	return pods, nil
 }
@@ -417,6 +448,28 @@ func filterByPodName(pods []v1.Pod, includedPodNames, excludedPodNames *regexp.R
 
 		if include && !exclude {
 			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList
+}
+
+func filterByOwnerReference(pods []v1.Pod) []v1.Pod {
+	owners := make(map[types.UID]struct{})
+	filteredList := []v1.Pod{}
+	for _, pod := range pods {
+		// Don't filter out pods with no owner reference
+		if len(pod.GetOwnerReferences()) == 0 {
+			filteredList = append(filteredList, pod)
+			continue
+		}
+
+		for _, ref := range pod.GetOwnerReferences() {
+			_, found := owners[ref.UID]
+			if !found {
+				filteredList = append(filteredList, pod)
+				owners[ref.UID] = struct{}{}
+			}
 		}
 	}
 

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -312,7 +312,7 @@ func (suite *Suite) TestNoVictimReturnsError() {
 		1,
 	)
 
-	_, err := chaoskube.Victim()
+	_, err := chaoskube.Victims()
 	suite.Equal(err, errPodNotFound)
 	suite.EqualError(err, "pod not found")
 }
@@ -649,11 +649,17 @@ func (suite *Suite) assertCandidates(chaoskube *Chaoskube, expected []map[string
 	suite.AssertPods(pods, expected)
 }
 
-func (suite *Suite) assertVictim(chaoskube *Chaoskube, expected map[string]string) {
-	victim, err := chaoskube.Victim()
+func (suite *Suite) assertVictims(chaoskube *Chaoskube, expected []map[string]string) {
+	victims, err := chaoskube.Victims()
 	suite.Require().NoError(err)
 
-	suite.AssertPod(victim, expected)
+	for i, victim := range victims {
+		suite.AssertPod(victim, expected[i])
+	}
+}
+
+func (suite *Suite) assertVictim(chaoskube *Chaoskube, expected map[string]string) {
+	suite.assertVictims(chaoskube, []map[string]string{expected})
 }
 
 func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, namespaceLabels labels.Selector, includedPodNames *regexp.Regexp, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration) *Chaoskube {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kingpin v0.0.0-20190705085659-95eb9edaa399
 	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/gophercloud/gophercloud v0.2.0 // indirect
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/sirupsen/logrus v1.4.2

--- a/main.go
+++ b/main.go
@@ -203,6 +203,7 @@ func main() {
 		log.StandardLogger(),
 		dryRun,
 		terminator.NewDeletePodTerminator(client, log.StandardLogger(), gracePeriod),
+		1,
 	)
 
 	if metricsAddress != "" {

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ var (
 	excludedDaysOfYear string
 	timezone           string
 	minimumAge         time.Duration
+	maxKill            int
 	master             string
 	kubeconfig         string
 	interval           time.Duration
@@ -72,6 +73,7 @@ func init() {
 	kingpin.Flag("excluded-days-of-year", "A list of days of a year when termination is suspended, e.g. Apr1,Dec24").StringVar(&excludedDaysOfYear)
 	kingpin.Flag("timezone", "The timezone by which to interpret the excluded weekdays and times of day, e.g. UTC, Local, Europe/Berlin. Defaults to UTC.").Default("UTC").StringVar(&timezone)
 	kingpin.Flag("minimum-age", "Minimum age of pods to consider for termination").Default("0s").DurationVar(&minimumAge)
+	kingpin.Flag("max-kill", "Specifies the maximum number of pods to be terminated per interval.").Default("1").IntVar(&maxKill)
 	kingpin.Flag("master", "The address of the Kubernetes cluster to target").StringVar(&master)
 	kingpin.Flag("kubeconfig", "Path to a kubeconfig file").StringVar(&kubeconfig)
 	kingpin.Flag("interval", "Interval between Pod terminations").Default("10m").DurationVar(&interval)
@@ -112,6 +114,7 @@ func main() {
 		"excludedDaysOfYear": excludedDaysOfYear,
 		"timezone":           timezone,
 		"minimumAge":         minimumAge,
+		"maxKill":            maxKill,
 		"master":             master,
 		"kubeconfig":         kubeconfig,
 		"interval":           interval,
@@ -148,6 +151,7 @@ func main() {
 		"includedPodNames": includedPodNames,
 		"excludedPodNames": excludedPodNames,
 		"minimumAge":       minimumAge,
+		"maxKill":          maxKill,
 	}).Info("setting pod filter")
 
 	parsedWeekdays := util.ParseWeekdays(excludedWeekdays)
@@ -203,7 +207,7 @@ func main() {
 		log.StandardLogger(),
 		dryRun,
 		terminator.NewDeletePodTerminator(client, log.StandardLogger(), gracePeriod),
-		1,
+		maxKill,
 	)
 
 	if metricsAddress != "" {

--- a/util/util.go
+++ b/util/util.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -136,7 +137,12 @@ func FormatDays(days []time.Time) []string {
 
 // NewPod returns a new pod instance for testing purposes.
 func NewPod(namespace, name string, phase v1.PodPhase) v1.Pod {
-	return v1.Pod{
+	return NewPodWithOwner(namespace, name, phase, "")
+}
+
+// NewPodWithOwner returns a new pod instance for testing purposes with a given owner UID
+func NewPodWithOwner(namespace, name string, phase v1.PodPhase, owner types.UID) v1.Pod {
+	pod := v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Pod",
@@ -156,6 +162,14 @@ func NewPod(namespace, name string, phase v1.PodPhase) v1.Pod {
 			Phase: phase,
 		},
 	}
+
+	if owner != "" {
+		pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{UID: owner},
+		}
+	}
+
+	return pod
 }
 
 // NewNamespace returns a new namespace instance for testing purposes.

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -169,10 +170,14 @@ func NewNamespace(name string) v1.Namespace {
 	}
 }
 
-func PodSubSlice(pods []v1.Pod, count int) []v1.Pod {
+// RandomPodSubSlice creates a shuffled subslice of the give pods slice
+func RandomPodSubSlice(pods []v1.Pod, count int) []v1.Pod {
 	maxCount := len(pods)
 	if count > maxCount {
 		count = maxCount
 	}
-	return pods[0:count]
+
+	rand.Shuffle(len(pods), func(i, j int) { pods[i], pods[j] = pods[j], pods[i] })
+	res := pods[0:count]
+	return res
 }

--- a/util/util.go
+++ b/util/util.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -167,4 +167,12 @@ func NewNamespace(name string) v1.Namespace {
 			},
 		},
 	}
+}
+
+func PodSubSlice(pods []v1.Pod, count int) []v1.Pod {
+	maxCount := len(pods)
+	if count > maxCount {
+		count = maxCount
+	}
+	return pods[0:count]
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
 )
 
 type Suite struct {
@@ -405,6 +406,29 @@ func (suite *Suite) TestNewNamespace() {
 
 	suite.Equal("name", namespace.Name)
 	suite.Equal("name", namespace.Labels["env"])
+}
+
+func (suite *Suite) TestRandomPodSublice() {
+	pods := []v1.Pod{
+		NewPod("default", "foo", v1.PodRunning),
+		NewPod("testing", "bar", v1.PodRunning),
+		NewPod("test", "baz", v1.PodRunning),
+	}
+
+	for _, tt := range []struct {
+		name     string
+		in       []v1.Pod
+		count    int
+		expected int
+	}{
+		{"max kill = len(pods)", pods, 3, 3},
+		{"empyt pod list should return empty subslice", []v1.Pod{}, 3, 0},
+		{"maxKill > len(pods)", pods[0:1], 3, 1},
+		{"maxKill = 0 ", pods, 0, 0},
+	} {
+		results := RandomPodSubSlice(tt.in, tt.count)
+		suite.Assert().Equal(len(results), tt.expected, tt.name)
+	}
 }
 
 func TestSuite(t *testing.T) {


### PR DESCRIPTION
The configuration flag --max-kill specifies the maximum number of pods to be terminated per run,
with a default value of 1, to maintain existing behavior.

Adds a new filter: filterByOwnerReference to avoid terminating multiple pods belonging to the
same owner. This prevents pods deployed together to be terminated at the same time.

In practice, no more than 1 pod per owner will be terminated during each run. All pods without an owner
reference are eligible to be terminated in the same batch (up to --max-kill value)

This a PoC to address https://github.com/linki/chaoskube/issues/152

@linki if you think this is a good approach, I'll add tests for the new behavior.

For context, this is very helpful for large clusters. With a `--max-kill=10` we can now terminate up to 10 pods per run, and most of the time belonging to different deployments/stateful sets.