### PR TITLE
Use context to cancel in-flight requests

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -125,7 +125,7 @@ func New(client kubernetes.Interface, labels, annotations, namespaces, namespace
 // described by channel next. It returns when the given context is canceled.
 func (c *Chaoskube) Run(ctx context.Context, next <-chan time.Time) {
 	for {
-		if err := c.TerminateVictims(); err != nil {
+		if err := c.TerminateVictims(ctx); err != nil {
 			c.Logger.WithField("err", err).Error("failed to terminate victim")
 			metrics.ErrorsTotal.Inc()
 		}
@@ -142,7 +142,7 @@ func (c *Chaoskube) Run(ctx context.Context, next <-chan time.Time) {
 
 // TerminateVictims picks and deletes a victim.
 // It respects the configured excluded weekdays, times of day and days of a year filters.
-func (c *Chaoskube) TerminateVictims() error {
+func (c *Chaoskube) TerminateVictims(ctx context.Context) error {
 	now := c.Now().In(c.Timezone)
 
 	for _, wd := range c.ExcludedWeekdays {
@@ -166,7 +166,7 @@ func (c *Chaoskube) TerminateVictims() error {
 		}
 	}
 
-	victims, err := c.Victims()
+	victims, err := c.Victims(ctx)
 	if err == errPodNotFound {
 		c.Logger.Debug(msgVictimNotFound)
 		return nil
@@ -177,7 +177,7 @@ func (c *Chaoskube) TerminateVictims() error {
 
 	var result *multierror.Error
 	for _, victim := range victims {
-		err = c.DeletePod(victim)
+		err = c.DeletePod(ctx, victim)
 		result = multierror.Append(result, err)
 	}
 
@@ -185,8 +185,8 @@ func (c *Chaoskube) TerminateVictims() error {
 }
 
 // Victims returns up to N pods as configured by MaxKill flag
-func (c *Chaoskube) Victims() ([]v1.Pod, error) {
-	pods, err := c.Candidates()
+func (c *Chaoskube) Victims(ctx context.Context) ([]v1.Pod, error) {
+	pods, err := c.Candidates(ctx)
 	if err != nil {
 		return []v1.Pod{}, err
 	}
@@ -203,10 +203,10 @@ func (c *Chaoskube) Victims() ([]v1.Pod, error) {
 
 // Candidates returns the list of pods that are available for termination.
 // It returns all pods that match the configured label, annotation and namespace selectors.
-func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
+func (c *Chaoskube) Candidates(ctx context.Context) ([]v1.Pod, error) {
 	listOptions := metav1.ListOptions{LabelSelector: c.Labels.String()}
 
-	podList, err := c.Client.CoreV1().Pods(v1.NamespaceAll).List(context.TODO(), listOptions)
+	podList, err := c.Client.CoreV1().Pods(v1.NamespaceAll).List(ctx, listOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 		return nil, err
 	}
 
-	pods, err = filterPodsByNamespaceLabels(pods, c.NamespaceLabels, c.Client)
+	pods, err = filterPodsByNamespaceLabels(ctx, pods, c.NamespaceLabels, c.Client)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (c *Chaoskube) Candidates() ([]v1.Pod, error) {
 
 // DeletePod deletes the given pod with the selected terminator.
 // It will not delete the pod if dry-run mode is enabled.
-func (c *Chaoskube) DeletePod(victim v1.Pod) error {
+func (c *Chaoskube) DeletePod(ctx context.Context, victim v1.Pod) error {
 	c.Logger.WithFields(log.Fields{
 		"namespace": victim.Namespace,
 		"name":      victim.Name,
@@ -245,7 +245,7 @@ func (c *Chaoskube) DeletePod(victim v1.Pod) error {
 	}
 
 	start := time.Now()
-	err := c.Terminator.Terminate(victim)
+	err := c.Terminator.Terminate(ctx, victim)
 	metrics.TerminationDurationSeconds.Observe(time.Since(start).Seconds())
 	if err != nil {
 		return err
@@ -324,7 +324,7 @@ func filterByNamespaces(pods []v1.Pod, namespaces labels.Selector) ([]v1.Pod, er
 }
 
 // filterPodsByNamespaceLabels filters a list of pods by a given label selector on their namespace.
-func filterPodsByNamespaceLabels(pods []v1.Pod, labels labels.Selector, client kubernetes.Interface) ([]v1.Pod, error) {
+func filterPodsByNamespaceLabels(ctx context.Context, pods []v1.Pod, labels labels.Selector, client kubernetes.Interface) ([]v1.Pod, error) {
 	// empty filter returns original list
 	if labels.Empty() {
 		return pods, nil
@@ -333,7 +333,7 @@ func filterPodsByNamespaceLabels(pods []v1.Pod, labels labels.Selector, client k
 	// find all namespaces matching the label selector
 	listOptions := metav1.ListOptions{LabelSelector: labels.String()}
 
-	namespaces, err := client.CoreV1().Namespaces().List(context.TODO(), listOptions)
+	namespaces, err := client.CoreV1().Namespaces().List(ctx, listOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/terminator/delete_pod.go
+++ b/terminator/delete_pod.go
@@ -28,13 +28,13 @@ func NewDeletePodTerminator(client kubernetes.Interface, logger log.FieldLogger,
 }
 
 // Terminate sends a request to Kubernetes to delete the pod.
-func (t *DeletePodTerminator) Terminate(victim v1.Pod) error {
+func (t *DeletePodTerminator) Terminate(ctx context.Context, victim v1.Pod) error {
 	t.logger.WithFields(log.Fields{
 		"namespace": victim.Namespace,
 		"name":      victim.Name,
 	}).Debug("calling deletePod endpoint")
 
-	return t.client.CoreV1().Pods(victim.Namespace).Delete(context.TODO(), victim.Name, deleteOptions(t.gracePeriod))
+	return t.client.CoreV1().Pods(victim.Namespace).Delete(ctx, victim.Name, deleteOptions(t.gracePeriod))
 }
 
 func deleteOptions(gracePeriod time.Duration) metav1.DeleteOptions {

--- a/terminator/delete_pod_test.go
+++ b/terminator/delete_pod_test.go
@@ -46,18 +46,18 @@ func (suite *DeletePodTerminatorSuite) TestTerminate() {
 	}
 
 	for _, pod := range pods {
-		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.Background(), &pod, metav1.CreateOptions{})
 		suite.Require().NoError(err)
 	}
 
 	victim := util.NewPod("default", "foo", v1.PodRunning)
 
-	err := terminator.Terminate(victim)
+	err := terminator.Terminate(context.Background(), victim)
 	suite.Require().NoError(err)
 
 	suite.AssertLog(logOutput, log.DebugLevel, "calling deletePod endpoint", log.Fields{"namespace": "default", "name": "foo"})
 
-	remainingPods, err := client.CoreV1().Pods(v1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	remainingPods, err := client.CoreV1().Pods(v1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
 	suite.Require().NoError(err)
 
 	suite.AssertPods(remainingPods.Items, []map[string]string{

--- a/terminator/terminator.go
+++ b/terminator/terminator.go
@@ -1,11 +1,13 @@
 package terminator
 
 import (
-	"k8s.io/api/core/v1"
+	"context"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 // Terminator is the interface for implementations of pod terminators.
 type Terminator interface {
 	// Terminate terminates the given pod.
-	Terminate(victim v1.Pod) error
+	Terminate(ctx context.Context, victim v1.Pod) error
 }


### PR DESCRIPTION
Now that client-go [supports a context](https://github.com/linki/chaoskube/pull/191) parameter we can actually support it in chaoskube as well.

I've never used context for anything else other than signal handling (like in chaoskube's main loop) and request timeouts. Both could be applied here but for now I'll use it for the former.

Before, if for some reason the call to the Kubernetes API was hanging, hitting Ctrl+C would just not work. Although the top-level context would have its cancel func called, we'd never read the Done channel until the request is completed, e.g. via some timeout.

Now, the top-level cancellable context is propagated down to client-go and Ctrl+C will actually preempt long running requests and the program can terminate immediately.