### PR TITLE
Filter by OwnerReference's Kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ INFO[0000] setting pod filter       namespaceLabels="!integration"
 
 This will exclude all pods from namespaces with the label `integration`.
 
+You can filter target pods by [OwnerReference's](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#OwnerReference) kind selector.
+
+```console
+$ chaoskube --kinds '!DaemonSet,!StatefulSet'
+...
+INFO[0000] setting pod filter       kinds="!DaemonSet,!StatefulSet"
+```
+
+This will exclude any `DaemonSet` and `StatefulSet` pods.
+
+```console
+$ chaoskube --kinds 'DaemonSet'
+...
+INFO[0000] setting pod filter       kinds="DaemonSet"
+```
+
+This will only include any `DaemonSet` pods. 
+
+Please note: any `include` filter will automatically exclude all the pods with no OwnerReference defined.
+
 You can filter pods by name:
 
 ```console
@@ -185,6 +205,7 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--interval`              | interval between pod terminations                                    | 10m                        |
 | `--labels`                | label selector to filter pods by                                     | (matches everything)       |
 | `--annotations`           | annotation selector to filter pods by                                | (matches everything)       |
+| `--kinds`                 | owner's kind selector to filter pods by                              | (all kinds)                |
 | `--namespaces`            | namespace selector to filter pods by                                 | (all namespaces)           |
 | `--namespace-labels`      | label selector to filter namespaces and its pods by                  | (all namespaces)           |
 | `--included-pod-names`    | regular expression pattern for pod names to include                  | (all included)             |

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -303,16 +303,6 @@ func filterByKinds(pods []v1.Pod, kinds labels.Selector) ([]v1.Pod, error) {
 	filteredList := []v1.Pod{}
 
 	for _, pod := range pods {
-		// Don't filter out pods with no owner reference
-		if len(pod.GetOwnerReferences()) == 0 && len(reqIncl) == 0 {
-			filteredList = append(filteredList, pod)
-			continue
-		}
-
-		if len(pod.GetOwnerReferences()) == 0 {
-			continue
-		}
-
 		// if there aren't any including requirements, we're in by default
 		included := len(reqIncl) == 0
 

--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -36,6 +36,8 @@ type Chaoskube struct {
 	Labels labels.Selector
 	// an annotation selector which restricts the pods to choose from
 	Annotations labels.Selector
+	// a kind label selector which restricts the kinds to choose from
+	Kinds labels.Selector
 	// a namespace selector which restricts the pods to choose from
 	Namespaces labels.Selector
 	// a namespace label selector which restricts the namespaces to choose from
@@ -56,7 +58,7 @@ type Chaoskube struct {
 	MinimumAge time.Duration
 	// an instance of logrus.StdLogger to write log messages to
 	Logger log.FieldLogger
-	// a terminator that termiantes victim pods
+	// a terminator that terminates victim pods
 	Terminator terminator.Terminator
 	// dry run will not allow any pod terminations
 	DryRun bool
@@ -93,7 +95,7 @@ var (
 // * a logger implementing logrus.FieldLogger to send log output to
 // * what specific terminator to use to imbue chaos on victim pods
 // * whether to enable/disable dry-run mode
-func New(client kubernetes.Interface, labels, annotations, namespaces, namespaceLabels labels.Selector, includedPodNames, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, terminator terminator.Terminator, maxKill int, notifier notifier.Notifier) *Chaoskube {
+func New(client kubernetes.Interface, labels, annotations, kinds, namespaces, namespaceLabels labels.Selector, includedPodNames, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, logger log.FieldLogger, dryRun bool, terminator terminator.Terminator, maxKill int, notifier notifier.Notifier) *Chaoskube {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: client.CoreV1().Events(v1.NamespaceAll)})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "chaoskube"})
@@ -102,6 +104,7 @@ func New(client kubernetes.Interface, labels, annotations, namespaces, namespace
 		Client:             client,
 		Labels:             labels,
 		Annotations:        annotations,
+		Kinds:              kinds,
 		Namespaces:         namespaces,
 		NamespaceLabels:    namespaceLabels,
 		IncludedPodNames:   includedPodNames,
@@ -223,6 +226,11 @@ func (c *Chaoskube) Candidates(ctx context.Context) ([]v1.Pod, error) {
 		return nil, err
 	}
 
+	pods, err = filterByKinds(pods, c.Kinds)
+	if err != nil {
+		return nil, err
+	}
+
 	pods = filterByAnnotations(pods, c.Annotations)
 	pods = filterByPhase(pods, v1.PodRunning)
 	pods = filterTerminatingPods(pods)
@@ -267,6 +275,75 @@ func (c *Chaoskube) DeletePod(ctx context.Context, victim v1.Pod) error {
 	}
 
 	return nil
+}
+
+// filterByKinds filters a list of pods by a given kind selector.
+func filterByKinds(pods []v1.Pod, kinds labels.Selector) ([]v1.Pod, error) {
+	// empty filter returns original list
+	if kinds.Empty() {
+		return pods, nil
+	}
+
+	// split requirements into including and excluding groups
+	reqs, _ := kinds.Requirements()
+	reqIncl := []labels.Requirement{}
+	reqExcl := []labels.Requirement{}
+
+	for _, req := range reqs {
+		switch req.Operator() {
+		case selection.Exists:
+			reqIncl = append(reqIncl, req)
+		case selection.DoesNotExist:
+			reqExcl = append(reqExcl, req)
+		default:
+			return nil, fmt.Errorf("unsupported operator: %s", req.Operator())
+		}
+	}
+
+	filteredList := []v1.Pod{}
+
+	for _, pod := range pods {
+		// Don't filter out pods with no owner reference
+		if len(pod.GetOwnerReferences()) == 0 && len(reqIncl) == 0 {
+			filteredList = append(filteredList, pod)
+			continue
+		}
+
+		if len(pod.GetOwnerReferences()) == 0 {
+			continue
+		}
+
+		// if there aren't any including requirements, we're in by default
+		included := len(reqIncl) == 0
+
+		// Check owner reference
+		for _, ref := range pod.GetOwnerReferences() {
+			// convert the pod's owner kind to an equivalent label selector
+			selector := labels.Set{ref.Kind: ""}
+
+			// include pod if one including requirement matches
+			for _, req := range reqIncl {
+				if req.Matches(selector) {
+					included = true
+					break
+				}
+			}
+
+			// exclude pod if it is filtered out by at least one excluding requirement
+			for _, req := range reqExcl {
+				if !req.Matches(selector) {
+					included = false
+					break
+				}
+			}
+		}
+
+		if included {
+			filteredList = append(filteredList, pod)
+		}
+	}
+
+	return filteredList, nil
 }
 
 // filterByNamespaces filters a list of pods by a given namespace selector.

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -51,6 +51,7 @@ func (suite *Suite) TestNew() {
 		client             = fake.NewSimpleClientset()
 		labelSelector, _   = labels.Parse("foo=bar")
 		annotations, _     = labels.Parse("baz=waldo")
+		kinds, _           = labels.Parse("job")
 		namespaces, _      = labels.Parse("qux")
 		namespaceLabels, _ = labels.Parse("taz=wubble")
 		includedPodNames   = regexp.MustCompile("foo")
@@ -69,6 +70,7 @@ func (suite *Suite) TestNew() {
 		client,
 		labelSelector,
 		annotations,
+		kinds,
 		namespaces,
 		namespaceLabels,
 		includedPodNames,
@@ -89,6 +91,7 @@ func (suite *Suite) TestNew() {
 	suite.Equal(client, chaoskube.Client)
 	suite.Equal("foo=bar", chaoskube.Labels.String())
 	suite.Equal("baz=waldo", chaoskube.Annotations.String())
+	suite.Equal("job", chaoskube.Kinds.String())
 	suite.Equal("qux", chaoskube.Namespaces.String())
 	suite.Equal("taz=wubble", chaoskube.NamespaceLabels.String())
 	suite.Equal("foo", chaoskube.IncludedPodNames.String())
@@ -106,6 +109,7 @@ func (suite *Suite) TestNew() {
 // TestRunContextCanceled tests that a canceled context will exit the Run function.
 func (suite *Suite) TestRunContextCanceled() {
 	chaoskube := suite.setup(
+		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
@@ -136,25 +140,29 @@ func (suite *Suite) TestCandidates() {
 	for _, tt := range []struct {
 		labelSelector      string
 		annotationSelector string
+		kindSelector       string
 		namespaceSelector  string
 		pods               []map[string]string
 	}{
-		{"", "", "", []map[string]string{foo, bar}},
-		{"app=foo", "", "", []map[string]string{foo}},
-		{"app!=foo", "", "", []map[string]string{bar}},
-		{"", "chaos=foo", "", []map[string]string{foo}},
-		{"", "chaos!=foo", "", []map[string]string{bar}},
-		{"", "", "default", []map[string]string{foo}},
-		{"", "", "default,testing", []map[string]string{foo, bar}},
-		{"", "", "!testing", []map[string]string{foo}},
-		{"", "", "!default,!testing", []map[string]string{}},
-		{"", "", "default,!testing", []map[string]string{foo}},
-		{"", "", "default,!default", []map[string]string{}},
+		{"", "", "", "", []map[string]string{foo, bar}},
+		{"app=foo", "", "", "", []map[string]string{foo}},
+		{"app!=foo", "", "", "", []map[string]string{bar}},
+		{"", "chaos=foo", "", "", []map[string]string{foo}},
+		{"", "chaos!=foo", "", "", []map[string]string{bar}},
+		{"", "", "", "default", []map[string]string{foo}},
+		{"", "", "", "default,testing", []map[string]string{foo, bar}},
+		{"", "", "", "!testing", []map[string]string{foo}},
+		{"", "", "", "!default,!testing", []map[string]string{}},
+		{"", "", "", "default,!testing", []map[string]string{foo}},
+		{"", "", "", "default,!default", []map[string]string{}},
 	} {
 		labelSelector, err := labels.Parse(tt.labelSelector)
 		suite.Require().NoError(err)
 
 		annotationSelector, err := labels.Parse(tt.annotationSelector)
+		suite.Require().NoError(err)
+
+		kindSelector, err := labels.Parse(tt.kindSelector)
 		suite.Require().NoError(err)
 
 		namespaceSelector, err := labels.Parse(tt.namespaceSelector)
@@ -163,6 +171,7 @@ func (suite *Suite) TestCandidates() {
 		chaoskube := suite.setupWithPods(
 			labelSelector,
 			annotationSelector,
+			kindSelector,
 			namespaceSelector,
 			labels.Everything(),
 			nil,
@@ -205,6 +214,7 @@ func (suite *Suite) TestCandidatesNamespaceLabels() {
 		suite.Require().NoError(err)
 
 		chaoskube := suite.setupWithPods(
+			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
@@ -251,6 +261,7 @@ func (suite *Suite) TestCandidatesPodNameRegexp() {
 			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
+			labels.Everything(),
 			tt.includedPodNames,
 			tt.excludedPodNames,
 			[]time.Weekday{},
@@ -287,6 +298,7 @@ func (suite *Suite) TestVictim() {
 
 		chaoskube := suite.setupWithPods(
 			labelSelector,
+			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
@@ -342,6 +354,7 @@ func (suite *Suite) TestVictims() {
 			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
+			labels.Everything(),
 			&regexp.Regexp{},
 			&regexp.Regexp{},
 			[]time.Weekday{},
@@ -362,6 +375,7 @@ func (suite *Suite) TestVictims() {
 // TestNoVictimReturnsError tests that on missing victim it returns a known error
 func (suite *Suite) TestNoVictimReturnsError() {
 	chaoskube := suite.setup(
+		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
@@ -400,6 +414,7 @@ func (suite *Suite) TestDeletePod() {
 			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
+			labels.Everything(),
 			&regexp.Regexp{},
 			&regexp.Regexp{},
 			[]time.Weekday{},
@@ -424,6 +439,7 @@ func (suite *Suite) TestDeletePod() {
 // TestDeletePodNotFound tests missing target pod will return an error.
 func (suite *Suite) TestDeletePodNotFound() {
 	chaoskube := suite.setup(
+		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
@@ -659,6 +675,7 @@ func (suite *Suite) TestTerminateVictim() {
 			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
+			labels.Everything(),
 			&regexp.Regexp{},
 			&regexp.Regexp{},
 			tt.excludedWeekdays,
@@ -684,6 +701,7 @@ func (suite *Suite) TestTerminateVictim() {
 // TestTerminateNoVictimLogsInfo tests that missing victim prints a log message
 func (suite *Suite) TestTerminateNoVictimLogsInfo() {
 	chaoskube := suite.setup(
+		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
@@ -732,10 +750,11 @@ func (suite *Suite) assertNotified(notifier *notifier.Noop) {
 	suite.Assert().Greater(notifier.Calls, 0)
 }
 
-func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, namespaceLabels labels.Selector, includedPodNames *regexp.Regexp, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration) *Chaoskube {
+func (suite *Suite) setupWithPods(labelSelector labels.Selector, annotations labels.Selector, kinds labels.Selector, namespaces labels.Selector, namespaceLabels labels.Selector, includedPodNames *regexp.Regexp, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration) *Chaoskube {
 	chaoskube := suite.setup(
 		labelSelector,
 		annotations,
+		kinds,
 		namespaces,
 		namespaceLabels,
 		includedPodNames,
@@ -783,7 +802,7 @@ func (suite *Suite) createPods(client kubernetes.Interface, podsInfo []podInfo) 
 	}
 }
 
-func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, namespaces labels.Selector, namespaceLabels labels.Selector, includedPodNames *regexp.Regexp, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration, maxKill int) *Chaoskube {
+func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Selector, kinds labels.Selector, namespaces labels.Selector, namespaceLabels labels.Selector, includedPodNames *regexp.Regexp, excludedPodNames *regexp.Regexp, excludedWeekdays []time.Weekday, excludedTimesOfDay []util.TimePeriod, excludedDaysOfYear []time.Time, timezone *time.Location, minimumAge time.Duration, dryRun bool, gracePeriod time.Duration, maxKill int) *Chaoskube {
 	logOutput.Reset()
 
 	client := fake.NewSimpleClientset()
@@ -793,6 +812,7 @@ func (suite *Suite) setup(labelSelector labels.Selector, annotations labels.Sele
 		client,
 		labelSelector,
 		annotations,
+		kinds,
 		namespaces,
 		namespaceLabels,
 		includedPodNames,
@@ -901,6 +921,7 @@ func (suite *Suite) TestMinimumAge() {
 			labels.Everything(),
 			labels.Everything(),
 			labels.Everything(),
+			labels.Everything(),
 			&regexp.Regexp{},
 			&regexp.Regexp{},
 			[]time.Weekday{},
@@ -940,6 +961,81 @@ func (suite *Suite) TestFilterDeletedPods() {
 	filtered := filterTerminatingPods(pods)
 	suite.Equal(len(filtered), 1)
 	suite.Equal(pods[0].Name, "running")
+}
+
+func (suite *Suite) TestFilterByKinds() {
+	foo := util.NewPodWithOwner("default", "foo", v1.PodRunning, "parent-1")
+	foo1 := util.NewPodWithOwner("default", "foo-1", v1.PodRunning, "parent-2")
+	bar := util.NewPodWithOwner("default", "bar", v1.PodRunning, "other-parent")
+	baz := util.NewPod("default", "baz", v1.PodRunning)
+	baz1 := util.NewPod("default", "baz-1", v1.PodRunning)
+
+	for _, tt := range []struct {
+		name     string
+		kinds    string
+		pods     []v1.Pod
+		expected []v1.Pod
+	}{
+		{
+			name:     "2 pods, one with owner ref",
+			kinds:    "testkind",
+			pods:     []v1.Pod{foo, baz},
+			expected: []v1.Pod{foo},
+		},
+		{
+			name:     "5 pods, 3 with owner ref",
+			kinds:    "!testkind",
+			pods:     []v1.Pod{foo, foo1, baz, bar, baz1},
+			expected: []v1.Pod{baz, baz1},
+		},
+		{
+			name:     "3 pods with owner ref, different kind",
+			kinds:    "!testkind",
+			pods:     []v1.Pod{foo, foo1, bar},
+			expected: []v1.Pod{},
+		},
+		{
+			name:     "3 pods with owner ref, different kind",
+			kinds:    "!testkind,!job",
+			pods:     []v1.Pod{foo, baz},
+			expected: []v1.Pod{baz},
+		},
+		{
+			name:     "3 pods with owner ref, different kind",
+			kinds:    "testkind,job",
+			pods:     []v1.Pod{foo, foo1, bar, baz},
+			expected: []v1.Pod{foo, foo1, bar},
+		},
+		{
+			name:     "3 pods with owner ref, different kind",
+			kinds:    "!testkind,job",
+			pods:     []v1.Pod{foo, foo1, bar, baz},
+			expected: []v1.Pod{},
+		},
+		{
+			name:     "3 pods with owner ref, different kind",
+			kinds:    "testkind,!job",
+			pods:     []v1.Pod{foo, foo1, bar, baz},
+			expected: []v1.Pod{foo, foo1, bar},
+		},
+		{
+			name:     "3 pods with owner ref, different kind",
+			kinds:    "job",
+			pods:     []v1.Pod{foo, foo1, bar, baz},
+			expected: []v1.Pod{},
+		},
+	} {
+		kindsSelector, err := labels.Parse(tt.kinds)
+		suite.Require().NoError(err)
+
+		results, err := filterByKinds(tt.pods, kindsSelector)
+		suite.Require().Len(results, len(tt.expected))
+		suite.Require().NoError(err)
+
+		for i, result := range results {
+			suite.Assert().Equal(tt.expected[i], result, tt.name)
+		}
+	}
 }
 
 func (suite *Suite) TestFilterByOwnerReference() {
@@ -1004,6 +1100,7 @@ func (suite *Suite) TestFilterByOwnerReference() {
 
 func (suite *Suite) TestNotifierCall() {
 	chaoskube := suite.setupWithPods(
+		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),
 		labels.Everything(),

--- a/chaoskube/chaoskube_test.go
+++ b/chaoskube/chaoskube_test.go
@@ -140,29 +140,25 @@ func (suite *Suite) TestCandidates() {
 	for _, tt := range []struct {
 		labelSelector      string
 		annotationSelector string
-		kindSelector       string
 		namespaceSelector  string
 		pods               []map[string]string
 	}{
-		{"", "", "", "", []map[string]string{foo, bar}},
-		{"app=foo", "", "", "", []map[string]string{foo}},
-		{"app!=foo", "", "", "", []map[string]string{bar}},
-		{"", "chaos=foo", "", "", []map[string]string{foo}},
-		{"", "chaos!=foo", "", "", []map[string]string{bar}},
-		{"", "", "", "default", []map[string]string{foo}},
-		{"", "", "", "default,testing", []map[string]string{foo, bar}},
-		{"", "", "", "!testing", []map[string]string{foo}},
-		{"", "", "", "!default,!testing", []map[string]string{}},
-		{"", "", "", "default,!testing", []map[string]string{foo}},
-		{"", "", "", "default,!default", []map[string]string{}},
+		{"", "", "", []map[string]string{foo, bar}},
+		{"app=foo", "", "", []map[string]string{foo}},
+		{"app!=foo", "", "", []map[string]string{bar}},
+		{"", "chaos=foo", "", []map[string]string{foo}},
+		{"", "chaos!=foo", "", []map[string]string{bar}},
+		{"", "", "default", []map[string]string{foo}},
+		{"", "", "default,testing", []map[string]string{foo, bar}},
+		{"", "", "!testing", []map[string]string{foo}},
+		{"", "", "!default,!testing", []map[string]string{}},
+		{"", "", "default,!testing", []map[string]string{foo}},
+		{"", "", "default,!default", []map[string]string{}},
 	} {
 		labelSelector, err := labels.Parse(tt.labelSelector)
 		suite.Require().NoError(err)
 
 		annotationSelector, err := labels.Parse(tt.annotationSelector)
-		suite.Require().NoError(err)
-
-		kindSelector, err := labels.Parse(tt.kindSelector)
 		suite.Require().NoError(err)
 
 		namespaceSelector, err := labels.Parse(tt.namespaceSelector)
@@ -171,7 +167,7 @@ func (suite *Suite) TestCandidates() {
 		chaoskube := suite.setupWithPods(
 			labelSelector,
 			annotationSelector,
-			kindSelector,
+			labels.Everything(),
 			namespaceSelector,
 			labels.Everything(),
 			nil,

--- a/examples/chaoskube.yaml
+++ b/examples/chaoskube.yaml
@@ -26,6 +26,8 @@ spec:
         - --labels=environment=test
         # only consider pods with this annotation
         - --annotations=chaos.alpha.kubernetes.io/enabled=true
+        # exclude all DaemonSet pods
+        - --kinds=!DaemonSet
         # exclude all pods in the kube-system namespace
         - --namespaces=!kube-system
         # don't kill anything on weekends

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 var (
 	labelString        string
 	annString          string
+	kindsString        string
 	nsString           string
 	nsLabelString      string
 	includedPodNames   *regexp.Regexp
@@ -66,6 +67,7 @@ func init() {
 
 	kingpin.Flag("labels", "A set of labels to restrict the list of affected pods. Defaults to everything.").StringVar(&labelString)
 	kingpin.Flag("annotations", "A set of annotations to restrict the list of affected pods. Defaults to everything.").StringVar(&annString)
+	kingpin.Flag("kinds", "A set of kinds to restrict the list of affected pods. Defaults to everything.").StringVar(&kindsString)
 	kingpin.Flag("namespaces", "A set of namespaces to restrict the list of affected pods. Defaults to everything.").StringVar(&nsString)
 	kingpin.Flag("namespace-labels", "A set of labels to restrict the list of affected namespaces. Defaults to everything.").StringVar(&nsLabelString)
 	kingpin.Flag("included-pod-names", "Regular expression that defines which pods to include. All included by default.").RegexpVar(&includedPodNames)
@@ -108,6 +110,7 @@ func main() {
 	log.WithFields(log.Fields{
 		"labels":             labelString,
 		"annotations":        annString,
+		"kinds":              kindsString,
 		"namespaces":         nsString,
 		"namespaceLabels":    nsLabelString,
 		"includedPodNames":   includedPodNames,
@@ -143,6 +146,7 @@ func main() {
 	var (
 		labelSelector   = parseSelector(labelString)
 		annotations     = parseSelector(annString)
+		kinds           = parseSelector(kindsString)
 		namespaces      = parseSelector(nsString)
 		namespaceLabels = parseSelector(nsLabelString)
 	)
@@ -150,6 +154,7 @@ func main() {
 	log.WithFields(log.Fields{
 		"labels":           labelSelector,
 		"annotations":      annotations,
+		"kinds":            kinds,
 		"namespaces":       namespaces,
 		"namespaceLabels":  namespaceLabels,
 		"includedPodNames": includedPodNames,
@@ -201,6 +206,7 @@ func main() {
 		client,
 		labelSelector,
 		annotations,
+		kinds,
 		namespaces,
 		namespaceLabels,
 		includedPodNames,

--- a/util/util.go
+++ b/util/util.go
@@ -165,7 +165,7 @@ func NewPodWithOwner(namespace, name string, phase v1.PodPhase, owner types.UID)
 
 	if owner != "" {
 		pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-			{UID: owner},
+			{UID: owner, Kind: "testkind"},
 		}
 	}
 


### PR DESCRIPTION
This PR adds new flag `--kinds`. 
It allows us to include/exclude specific Kinds of pods or, to be more specific, filter by OwnerReference's Kind.

So, for example, you can exclude any pods created by any DaemonSet by using the following flag:

```
--kinds="!DaemonSet"
```
