### PR TITLE
Added test & build to makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.prof
 
 /vendor
+/bin

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,5 @@ coveralls:
 
 test: check
 
-build: go build -o /bin/chaoskube -v
+build: 
+	go build -o bin/chaoskube -v

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ endif
 coveralls:
 	roveralls
 	goveralls -coverprofile=roveralls.coverprofile -service=travis-ci
+
+test: check
+
+build: go build -o /bin/chaoskube -v


### PR DESCRIPTION
References: #146 

Added `make test` &  `make build`

test - Since check is already added, test redirects and runs `make check`

build - added `make build` to run `go build` and generate the binary in `bin/chaoskube`
