### PR TITLE
add a helm chart to deploy chaoskube

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,46 @@
+---
+name: helm
+on:
+  push:
+    branches:
+      - master
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      chart: ${{ steps.filter.outputs.chart }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            chart:
+              - 'chart/chaoskube/Chart.yaml'
+              - 'chart/chaoskube/**/*'
+  chart:
+    name: release chart
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+    if: |
+      needs.changes.outputs.chart == 'true'
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          # Fetch entire history. Required for chart-releaser; see https://github.com/helm/chart-releaser-action/issues/13#issuecomment-602063896
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"
+        with:
+          charts_dir: chart

--- a/chart/chaoskube/.helmignore
+++ b/chart/chaoskube/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/chaoskube/Chart.yaml
+++ b/chart/chaoskube/Chart.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v2
+name: chaoskube
+type: application
+description: Chaoskube periodically kills random pods in your Kubernetes cluster.
+icon: https://raw.githubusercontent.com/linki/chaoskube/master/chaoskube.png
+home: https://github.com/linki/chaoskube
+keywords:
+  - chaos-monkey
+  - chaos-engineering
+maintainers:
+  - name: Martin Linkhorst
+    url: https://github.com/linki
+  - name: Thomas Gosteli
+    url: https://github.com/ghouscht
+version: 0.1.0
+appVersion: 0.21.0

--- a/chart/chaoskube/README.md
+++ b/chart/chaoskube/README.md
@@ -1,0 +1,14 @@
+# chaoskube Helm Chart
+chaoskube periodically kills random pods in your Kubernetes cluster.
+
+## Installation
+
+### Helm 3: install the chaoskube Helm Chart
+```
+helm repo add chaoskube https://chaoskube.github.io/chaoskube-kubernetes
+helm install ...
+
+```
+
+## Example Helm values
+...

--- a/chart/chaoskube/templates/NOTES.txt
+++ b/chart/chaoskube/templates/NOTES.txt
@@ -1,0 +1,2 @@
+Chaoskube successfully installed in namespace {{ .Release.Namespace }}.
+Please visit https://github.com/linki/chaoskube for further information.

--- a/chart/chaoskube/templates/_helpers.tpl
+++ b/chart/chaoskube/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chaoskube.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chaoskube.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chaoskube.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chaoskube.labels" -}}
+helm.sh/chart: {{ include "chaoskube.chart" . }}
+{{ include "chaoskube.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chaoskube.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chaoskube.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chaoskube.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chaoskube.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/chaoskube/templates/clusterrole.yaml
+++ b/chart/chaoskube/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "chaoskube.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]

--- a/chart/chaoskube/templates/clusterrolebinding.yaml
+++ b/chart/chaoskube/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "chaoskube.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "chaoskube.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "chaoskube.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/chart/chaoskube/templates/deployment.yaml
+++ b/chart/chaoskube/templates/deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chaoskube.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chaoskube.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chaoskube.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chaoskube.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "chaoskube.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.chaoskube.env }}
+        env:
+          {{ toYaml .Values.chaoskube.env | indent 8 }}
+        {{- end }}
+        args:
+        {{- range $key, $value := .Values.chaoskube.args }}
+        {{- if $value }}
+        - --{{ $key }}={{ $value }}
+        {{- else }}
+        - --{{ $key }}
+        {{- end }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.podSecurityContext | nindent 10 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}

--- a/chart/chaoskube/templates/serviceaccount.yaml
+++ b/chart/chaoskube/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chaoskube.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chaoskube.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/chart/chaoskube/values.yaml
+++ b/chart/chaoskube/values.yaml
@@ -1,0 +1,63 @@
+---
+# replicaCount configures the number of replicas to run
+replicaCount: 1
+
+# image specifies image location, tag and pullPolicy
+image:
+  repository: quay.io/linki/chaoskube
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# chaoskube is used to configure chaoskube
+chaoskube:
+  env: {}
+  args:
+    # kill a pod every 10 minutes
+    interval: "10m"
+    # only target pods in the test environment
+    labels: "environment=test"
+    # only consider pods with this annotation
+    annotations: "chaos.alpha.kubernetes.io/enabled=true"
+    # exclude all DaemonSet pods
+    kinds: "!DaemonSet"
+    # exclude all pods in the kube-system namespace
+    namespaces: "!kube-system"
+    # don't kill anything on weekends
+    excluded-weekdays: "Sat,Sun"
+    # don't kill anything during the night or at lunchtime
+    excluded-times-of-day: "22:00-08:00,11:00-13:00"
+    # don't kill anything as a joke or on christmas eve
+    excluded-days-of-year: "Apr1,Dec24"
+    # let's make sure we all agree on what the above times mean
+    timezone: "UTC"
+    # exclude all pods that haven't been running for at least one hour
+    minimum-age: "1h"
+    # terminate pods for real: this disables dry-run mode which is on by default
+    no-dry-run: ""
+
+# serviceAccount can be used to customize the service account which will be crated and used by chaoskube
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# podAnnotations can be used to add additional annotations to the pod
+podAnnotations: {}
+
+# podSecurityContext is used to customize the security context of the pod
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+# resources can be used to limit pod compute resources (limits/requests)
+resources: {}
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 10m
+#   memory: 16Mi


### PR DESCRIPTION
Quickly hacked together, needs some detailing. Waiting on feedback 😃 See also #275  You can already run `helm template chart/chaoskube/` to see/apply the rendered manifests