### PR TITLE
Add maximum runtime flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Use `UTC`, `Local` or pick a timezone name from the [(IANA) tz database](https:/
 | `--excluded-times-of-day` | times of day when chaos is to be suspended, e.g. "22:00-08:00"       | (no times of day excluded) |
 | `--excluded-days-of-year` | days of a year when chaos is to be suspended, e.g. "Apr1,Dec24"      | (no days of year excluded) |
 | `--timezone`              | timezone from tz database, e.g. "America/New_York", "UTC" or "Local" | (UTC)                      |
+| `--max-runtime`           | Maximum runtime before chaoskube exits                               | -1s (infinite time)        |
 | `--max-kill`              | Specifies the maximum number of pods to be terminated per interval   | 1                          |
 | `--minimum-age`           | Minimum age to filter pods by                                        | 0s (matches every pod)     |
 | `--dry-run`               | don't kill pods, only log what would have been done                  | true                       |

--- a/examples/deployment/chaoskube.yaml
+++ b/examples/deployment/chaoskube.yaml
@@ -48,12 +48,3 @@ spec:
           readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
-
----
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: chaoskube
-  labels:
-    app: chaoskube

--- a/examples/job/chaoskube.yaml
+++ b/examples/job/chaoskube.yaml
@@ -1,0 +1,50 @@
+# chaoskube can stop after some time. This can be done
+# if it is deployed as a Job and having --max-runtime set as well
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube
+spec:
+  template:
+    metadata:
+      labels:
+        app: chaoskube
+    spec:
+      restartPolicy: Never
+      serviceAccountName: chaoskube
+      containers:
+      - name: chaoskube
+        image: quay.io/linki/chaoskube:v0.22.0
+        args:
+        # kill a pod every 10 minutes
+        - --interval=10m
+        # only target pods in the test environment
+        - --labels=environment=test
+        # only consider pods with this annotation
+        - --annotations=chaos.alpha.kubernetes.io/enabled=true
+        # exclude all DaemonSet pods
+        - --kinds=!DaemonSet
+        # exclude all pods in the kube-system namespace
+        - --namespaces=!kube-system
+        # don't kill anything on weekends
+        - --excluded-weekdays=Sat,Sun
+        # don't kill anything during the night or at lunchtime
+        - --excluded-times-of-day=22:00-08:00,11:00-13:00
+        # don't kill anything as a joke or on christmas eve
+        - --excluded-days-of-year=Apr1,Dec24
+        # let's make sure we all agree on what the above times mean
+        - --timezone=UTC
+        # exclude all pods that haven't been running for at least one hour
+        - --minimum-age=1h
+        # terminate pods for real: this disables dry-run mode which is on by default
+        - --no-dry-run
+        # if set, chaoskube will exit after the max runtime
+        - --max-runtime=3600s
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]

--- a/examples/rbac.yaml
+++ b/examples/rbac.yaml
@@ -22,3 +22,10 @@ subjects:
 - kind: ServiceAccount
   name: chaoskube
   namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube

--- a/main.go
+++ b/main.go
@@ -234,18 +234,13 @@ func main() {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 
-	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-	)
-
-	if maxRuntime <= 0 {
-		ctx, cancel = context.WithCancel(context.Background())
-	} else {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(maxRuntime))
-	}
-
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	if maxRuntime > -1 {
+		ctx, cancel = context.WithTimeout(ctx, maxRuntime)
+		defer cancel()
+	}
 
 	go func() {
 		<-done

--- a/main.go
+++ b/main.go
@@ -235,12 +235,12 @@ func main() {
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	if maxRuntime > -1 {
 		ctx, cancel = context.WithTimeout(ctx, maxRuntime)
-		defer cancel()
 	}
+
+	defer cancel()
 
 	go func() {
 		<-done


### PR DESCRIPTION
This could be the solution to the #271, regarding the flag, which gracefully shuts down chaoskube.
<img width="457" alt="Bildschirmfoto 2021-03-28 um 19 48 21" src="https://user-images.githubusercontent.com/81440191/112762211-c84eba80-8ffe-11eb-96a9-f0e4493b918d.png">
<img width="1662" alt="Bildschirmfoto 2021-03-28 um 19 48 51" src="https://user-images.githubusercontent.com/81440191/112762227-d43a7c80-8ffe-11eb-8d4e-133a84034000.png">

