### PR TITLE
Add namespace metadata to deleted pods metric

### DIFF
--- a/chaoskube/chaoskube.go
+++ b/chaoskube/chaoskube.go
@@ -261,7 +261,7 @@ func (c *Chaoskube) DeletePod(ctx context.Context, victim v1.Pod) error {
 		return err
 	}
 
-	metrics.PodsDeletedTotal.Inc()
+	metrics.PodsDeletedTotal.WithLabelValues(victim.Namespace).Inc()
 
 	ref, err := reference.GetReference(scheme.Scheme, &victim)
 	if err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,11 +7,11 @@ import (
 
 var (
 	// PodsDeletedTotal is the total number of deleted pods.
-	PodsDeletedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	PodsDeletedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "chaoskube",
 		Name:      "pods_deleted_total",
 		Help:      "The total number of pods deleted",
-	})
+	}, []string{"namespace"})
 	// IntervalsTotal is the total number of intervals, i.e. call to Run().
 	IntervalsTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "chaoskube",


### PR DESCRIPTION
Adds the namespace as a label to the pods_deleted metric. The result looks like this:

Fixes https://github.com/linki/chaoskube/issues/150

```console
# HELP chaoskube_pods_deleted_total The total number of pods deleted
# TYPE chaoskube_pods_deleted_total counter
chaoskube_pods_deleted_total{namespace="baz"} 1
chaoskube_pods_deleted_total{namespace="api"} 1
chaoskube_pods_deleted_total{namespace="cassandra"} 1
chaoskube_pods_deleted_total{namespace="foobar"} 1
chaoskube_pods_deleted_total{namespace="default"} 27
chaoskube_pods_deleted_total{namespace="kube-system"} 31
chaoskube_pods_deleted_total{namespace="github"} 1
chaoskube_pods_deleted_total{namespace="myspace"} 1
chaoskube_pods_deleted_total{namespace="other"} 4
```