### PR TITLE
Adds ability to configure frequency for pod termination via annotation

### DIFF
--- a/chart/chaoskube/Chart.yaml
+++ b/chart/chaoskube/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
   - name: Thomas Gosteli
     url: https://github.com/ghouscht
 version: 0.1.0
-appVersion: 0.21.0
+appVersion: 0.22.0

--- a/chart/chaoskube/templates/clusterrole.yaml
+++ b/chart/chaoskube/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -10,3 +11,4 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create"]
+{{- end }}

--- a/chart/chaoskube/templates/clusterrolebinding.yaml
+++ b/chart/chaoskube/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -11,3 +12,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "chaoskube.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/chaoskube/templates/deployment.yaml
+++ b/chart/chaoskube/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "chaoskube.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "chaoskube.serviceAccountName" . }}
       containers:
@@ -38,6 +41,14 @@ spec:
         {{- else }}
         - --{{ $key }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.chaoskube.metrics.enabled }}
+        - --metrics-address={{ .Values.chaoskube.metrics.port }}
+        {{- end }}
+        {{- if .Values.chaoskube.metrics.enabled }}
+        ports:
+          - name: metrics
+            containerPort: {{ .Values.chaoskube.metrics.port }}
         {{- end }}
         securityContext:
           {{- toYaml .Values.podSecurityContext | nindent 10 }}

--- a/chart/chaoskube/templates/service.yaml
+++ b/chart/chaoskube/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.chaoskube.metrics.enabled .Values.chaoskube.metrics.service.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chaoskube.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chaoskube.labels" . | nindent 4 }}
+
+spec:
+  type: {{ .Values.chaoskube.metrics.service.type }}
+
+  ports:
+    - port: {{ .Values.chaoskube.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: {{ include "chaoskube.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/chaoskube/templates/serviceaccount.yaml
+++ b/chart/chaoskube/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -10,3 +11,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/chart/chaoskube/values.yaml
+++ b/chart/chaoskube/values.yaml
@@ -12,6 +12,7 @@ image:
 # chaoskube is used to configure chaoskube
 chaoskube:
   env: {}
+
   args:
     # kill a pod every 10 minutes
     interval: "10m"
@@ -39,14 +40,29 @@ chaoskube:
     # terminate pods for real: this disables dry-run mode which is on by default
     no-dry-run: ""
 
+  metrics:
+    enabled: true
+    port: 8080
+
+    service:
+      create: true
+      type: ClusterIP
+
 # serviceAccount can be used to customize the service account which will be crated and used by chaoskube
 serviceAccount:
   create: true
   name: ""
   annotations: {}
 
+# rbac allows configuring the permissions for chaoskube
+rbac:
+  create: true
+
 # podAnnotations can be used to add additional annotations to the pod
 podAnnotations: {}
+
+# podAnnotations can be used to add additional labels to the pod
+podLabels: {}
 
 # podSecurityContext is used to customize the security context of the pod
 podSecurityContext:

--- a/chart/chaoskube/values.yaml
+++ b/chart/chaoskube/values.yaml
@@ -33,6 +33,9 @@ chaoskube:
     timezone: "UTC"
     # exclude all pods that haven't been running for at least one hour
     minimum-age: "1h"
+    # checks for "chaos.alpha.kubernetes.io/frequency" annotation on pods to determine frequency to terminate
+    # eg. setting "chaos.alpha.kubernetes.io/frequency=1/hour" will terminate the pod approximately once per hour
+    termination-frequency-annotation: "chaos.alpha.kubernetes.io/frequency"
     # terminate pods for real: this disables dry-run mode which is on by default
     no-dry-run: ""
 

--- a/main.go
+++ b/main.go
@@ -15,9 +15,9 @@ import (
 	"syscall"
 	"time"
 
-	"gopkg.in/alecthomas/kingpin.v2"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -36,30 +36,31 @@ var (
 )
 
 var (
-	labelString        string
-	annString          string
-	kindsString        string
-	nsString           string
-	nsLabelString      string
-	includedPodNames   *regexp.Regexp
-	excludedPodNames   *regexp.Regexp
-	excludedWeekdays   string
-	excludedTimesOfDay string
-	excludedDaysOfYear string
-	timezone           string
-	minimumAge         time.Duration
-	maxRuntime         time.Duration
-	maxKill            int
-	master             string
-	kubeconfig         string
-	interval           time.Duration
-	dryRun             bool
-	debug              bool
-	metricsAddress     string
-	gracePeriod        time.Duration
-	logFormat          string
-	logCaller          bool
-	slackWebhook       string
+	labelString         string
+	annString           string
+	kindsString         string
+	nsString            string
+	nsLabelString       string
+	includedPodNames    *regexp.Regexp
+	excludedPodNames    *regexp.Regexp
+	excludedWeekdays    string
+	excludedTimesOfDay  string
+	excludedDaysOfYear  string
+	timezone            string
+	minimumAge          time.Duration
+	frequencyAnnotation string
+	maxRuntime          time.Duration
+	maxKill             int
+	master              string
+	kubeconfig          string
+	interval            time.Duration
+	dryRun              bool
+	debug               bool
+	metricsAddress      string
+	gracePeriod         time.Duration
+	logFormat           string
+	logCaller           bool
+	slackWebhook        string
 )
 
 func init() {
@@ -78,6 +79,7 @@ func init() {
 	kingpin.Flag("excluded-days-of-year", "A list of days of a year when termination is suspended, e.g. Apr1,Dec24").StringVar(&excludedDaysOfYear)
 	kingpin.Flag("timezone", "The timezone by which to interpret the excluded weekdays and times of day, e.g. UTC, Local, Europe/Berlin. Defaults to UTC.").Default("UTC").StringVar(&timezone)
 	kingpin.Flag("minimum-age", "Minimum age of pods to consider for termination").Default("0s").DurationVar(&minimumAge)
+	kingpin.Flag("termination-frequency-annotation", "Annotation to look for on pods describing how frequently a pod should be terminated.").StringVar(&frequencyAnnotation)
 	kingpin.Flag("max-runtime", "Maximum runtime before chaoskube exits").Default("-1s").DurationVar(&maxRuntime)
 	kingpin.Flag("max-kill", "Specifies the maximum number of pods to be terminated per interval.").Default("1").IntVar(&maxKill)
 	kingpin.Flag("master", "The address of the Kubernetes cluster to target").StringVar(&master)
@@ -110,29 +112,30 @@ func main() {
 	log.SetReportCaller(logCaller)
 
 	log.WithFields(log.Fields{
-		"labels":             labelString,
-		"annotations":        annString,
-		"kinds":              kindsString,
-		"namespaces":         nsString,
-		"namespaceLabels":    nsLabelString,
-		"includedPodNames":   includedPodNames,
-		"excludedPodNames":   excludedPodNames,
-		"excludedWeekdays":   excludedWeekdays,
-		"excludedTimesOfDay": excludedTimesOfDay,
-		"excludedDaysOfYear": excludedDaysOfYear,
-		"timezone":           timezone,
-		"minimumAge":         minimumAge,
-		"maxRuntime":         maxRuntime,
-		"maxKill":            maxKill,
-		"master":             master,
-		"kubeconfig":         kubeconfig,
-		"interval":           interval,
-		"dryRun":             dryRun,
-		"debug":              debug,
-		"metricsAddress":     metricsAddress,
-		"gracePeriod":        gracePeriod,
-		"logFormat":          logFormat,
-		"slackWebhook":       slackWebhook,
+		"labels":              labelString,
+		"annotations":         annString,
+		"kinds":               kindsString,
+		"namespaces":          nsString,
+		"namespaceLabels":     nsLabelString,
+		"includedPodNames":    includedPodNames,
+		"excludedPodNames":    excludedPodNames,
+		"excludedWeekdays":    excludedWeekdays,
+		"excludedTimesOfDay":  excludedTimesOfDay,
+		"excludedDaysOfYear":  excludedDaysOfYear,
+		"timezone":            timezone,
+		"minimumAge":          minimumAge,
+		"frequencyAnnotation": frequencyAnnotation,
+		"maxRuntime":          maxRuntime,
+		"maxKill":             maxKill,
+		"master":              master,
+		"kubeconfig":          kubeconfig,
+		"interval":            interval,
+		"dryRun":              dryRun,
+		"debug":               debug,
+		"metricsAddress":      metricsAddress,
+		"gracePeriod":         gracePeriod,
+		"logFormat":           logFormat,
+		"slackWebhook":        slackWebhook,
 	}).Debug("reading config")
 
 	log.WithFields(log.Fields{
@@ -156,15 +159,16 @@ func main() {
 	)
 
 	log.WithFields(log.Fields{
-		"labels":           labelSelector,
-		"annotations":      annotations,
-		"kinds":            kinds,
-		"namespaces":       namespaces,
-		"namespaceLabels":  namespaceLabels,
-		"includedPodNames": includedPodNames,
-		"excludedPodNames": excludedPodNames,
-		"minimumAge":       minimumAge,
-		"maxKill":          maxKill,
+		"labels":              labelSelector,
+		"annotations":         annotations,
+		"kinds":               kinds,
+		"namespaces":          namespaces,
+		"namespaceLabels":     namespaceLabels,
+		"includedPodNames":    includedPodNames,
+		"excludedPodNames":    excludedPodNames,
+		"minimumAge":          minimumAge,
+		"frequencyAnnotation": frequencyAnnotation,
+		"maxKill":             maxKill,
 	}).Info("setting pod filter")
 
 	parsedWeekdays := util.ParseWeekdays(excludedWeekdays)
@@ -208,6 +212,7 @@ func main() {
 
 	chaoskube := chaoskube.New(
 		client,
+		interval,
 		labelSelector,
 		annotations,
 		kinds,
@@ -220,6 +225,7 @@ func main() {
 		parsedDaysOfYear,
 		parsedTimezone,
 		minimumAge,
+		frequencyAnnotation,
 		log.StandardLogger(),
 		dryRun,
 		terminator.NewDeletePodTerminator(client, log.StandardLogger(), gracePeriod),

--- a/notifier/slack_test.go
+++ b/notifier/slack_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/linki/chaoskube/internal/testutil"
 	"github.com/linki/chaoskube/util"
 
@@ -28,7 +26,7 @@ func (suite *SlackSuite) TestSlackNotificationForTerminationStatusOk() {
 	}))
 	defer testServer.Close()
 
-	testPod := util.NewPod("chaos", "chaos-57df4db6b-h9ktj", v1.PodRunning)
+	testPod := util.NewPodBuilder("chaos", "chaos-57df4db6b-h9ktj").Build()
 
 	slack := NewSlackNotifier(testServer.URL + webhookPath)
 	err := slack.NotifyPodTermination(testPod)
@@ -47,7 +45,7 @@ func (suite *SlackSuite) TestSlackNotificationForTerminationStatus500() {
 	}))
 	defer testServer.Close()
 
-	testPod := util.NewPod("chaos", "chaos-57df4db6b-h9ktj", v1.PodRunning)
+	testPod := util.NewPodBuilder("chaos", "chaos-57df4db6b-h9ktj").Build()
 
 	slack := NewSlackNotifier(testServer.URL + webhookPath)
 	err := slack.NotifyPodTermination(testPod)

--- a/terminator/delete_pod_test.go
+++ b/terminator/delete_pod_test.go
@@ -41,8 +41,8 @@ func (suite *DeletePodTerminatorSuite) TestTerminate() {
 	terminator := NewDeletePodTerminator(client, logger, 10*time.Second)
 
 	pods := []v1.Pod{
-		util.NewPod("default", "foo", v1.PodRunning),
-		util.NewPod("testing", "bar", v1.PodRunning),
+		util.NewPodBuilder("default", "foo").Build(),
+		util.NewPodBuilder("testing", "bar").Build(),
 	}
 
 	for _, pod := range pods {
@@ -50,7 +50,7 @@ func (suite *DeletePodTerminatorSuite) TestTerminate() {
 		suite.Require().NoError(err)
 	}
 
-	victim := util.NewPod("default", "foo", v1.PodRunning)
+	victim := util.NewPodBuilder("default", "foo").Build()
 
 	err := terminator.Terminate(context.Background(), victim)
 	suite.Require().NoError(err)

--- a/util/util.go
+++ b/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -120,6 +121,35 @@ func ParseDays(days string) ([]time.Time, error) {
 	return parsedDays, nil
 }
 
+// Parses a "frequency" annotation in the form "[number] / [period]" (eg. 1/day)
+// and converts it into a chance of occurrence in any given interval (eg. ~0.007)
+func ParseFrequency(text string, interval time.Duration) (float64, error) {
+	parseablePeriods := map[string]time.Duration{
+		"minute": 1 * time.Minute,
+		"hour":   1 * time.Hour,
+		"day":    24 * time.Hour,
+		"week":   24 * 7 * time.Hour,
+	}
+
+	parts := strings.SplitN(text, "/", 2)
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+
+	frequency, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return 0, err
+	}
+
+	period, ok := parseablePeriods[parts[1]]
+	if !ok {
+		return 0, fmt.Errorf("unknown time period, %v", parts[1])
+	}
+
+	chance := (float64(interval) / float64(period)) * frequency
+	return chance, nil
+}
+
 // TimeOfDay normalizes the given point in time by returning a time object that represents the same
 // time of day of the given time but on the very first day (day 0).
 func TimeOfDay(pointInTime time.Time) time.Time {
@@ -133,43 +163,6 @@ func FormatDays(days []time.Time) []string {
 		formattedDays = append(formattedDays, d.Format(YearDay))
 	}
 	return formattedDays
-}
-
-// NewPod returns a new pod instance for testing purposes.
-func NewPod(namespace, name string, phase v1.PodPhase) v1.Pod {
-	return NewPodWithOwner(namespace, name, phase, "")
-}
-
-// NewPodWithOwner returns a new pod instance for testing purposes with a given owner UID
-func NewPodWithOwner(namespace, name string, phase v1.PodPhase, owner types.UID) v1.Pod {
-	pod := v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-			Labels: map[string]string{
-				"app": name,
-			},
-			Annotations: map[string]string{
-				"chaos": name,
-			},
-			SelfLink: fmt.Sprintf("/api/v1/namespaces/%s/pods/%s", namespace, name),
-		},
-		Status: v1.PodStatus{
-			Phase: phase,
-		},
-	}
-
-	if owner != "" {
-		pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-			{UID: owner, Kind: "testkind"},
-		}
-	}
-
-	return pod
 }
 
 // NewNamespace returns a new namespace instance for testing purposes.
@@ -194,4 +187,78 @@ func RandomPodSubSlice(pods []v1.Pod, count int) []v1.Pod {
 	rand.Shuffle(len(pods), func(i, j int) { pods[i], pods[j] = pods[j], pods[i] })
 	res := pods[0:count]
 	return res
+}
+
+type PodBuilder struct {
+	Name           string
+	Namespace      string
+	Phase          v1.PodPhase
+	OwnerReference *metav1.OwnerReference
+	Labels         map[string]string
+	Annotations    map[string]string
+}
+
+func NewPodBuilder(namespace string, name string) PodBuilder {
+	return PodBuilder{
+		Name:           name,
+		Namespace:      namespace,
+		Phase:          v1.PodRunning,
+		OwnerReference: nil,
+		Annotations:    make(map[string]string),
+		Labels:         make(map[string]string),
+	}
+}
+
+func (b PodBuilder) Build() v1.Pod {
+	pod := v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   b.Namespace,
+			Name:        b.Name,
+			Labels:      b.Labels,
+			Annotations: b.Annotations,
+			SelfLink: fmt.Sprintf(
+				"/api/v1/namespaces/%s/pods/%s",
+				b.Namespace,
+				b.Name,
+			),
+		},
+		Status: v1.PodStatus{
+			Phase: b.Phase,
+		},
+	}
+
+	if b.OwnerReference != nil {
+		pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*b.OwnerReference}
+	}
+
+	return pod
+}
+
+func (b PodBuilder) WithPhase(phase v1.PodPhase) PodBuilder {
+	b.Phase = phase
+	return b
+}
+func (b PodBuilder) WithOwnerReference(ownerReference metav1.OwnerReference) PodBuilder {
+	b.OwnerReference = &ownerReference
+	return b
+}
+func (b PodBuilder) WithOwnerUID(owner types.UID) PodBuilder {
+	b.OwnerReference = &metav1.OwnerReference{UID: owner, Kind: "testkind"}
+	return b
+}
+func (b PodBuilder) WithAnnotations(annotations map[string]string) PodBuilder {
+	b.Annotations = annotations
+	return b
+}
+func (b PodBuilder) WithLabels(labels map[string]string) PodBuilder {
+	b.Labels = labels
+	return b
+}
+func (b PodBuilder) WithFrequency(text string) PodBuilder {
+	b.Annotations["chaos.alpha.kubernetes.io/frequency"] = text
+	return b
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -366,6 +366,34 @@ func (suite *Suite) TestParseDates() {
 	}
 }
 
+func (suite *Suite) TestParseFrequency() {
+	interval := 10 * time.Minute
+
+	for _, tt := range []struct {
+		given          string
+		expectedApprox float64
+	}{
+		{
+			"1 / hour",
+			0.166666667,
+		}, {
+			"1 / minute",
+			10.0,
+		}, {
+			"2.5 / hour",
+			0.416666667,
+		}, {
+			"60 / day",
+			0.416666667,
+		},
+	} {
+		result, err := ParseFrequency(tt.given, interval)
+		suite.Require().NoError(err)
+
+		suite.Assert().InDelta(tt.expectedApprox, result, 0.001)
+	}
+}
+
 func (suite *Suite) TestFormatDays() {
 	for _, tt := range []struct {
 		given    []time.Time
@@ -389,7 +417,8 @@ func (suite *Suite) TestFormatDays() {
 }
 
 func (suite *Suite) TestNewPod() {
-	pod := NewPod("namespace", "name", "phase")
+	pod := NewPodBuilder("namespace", "name").
+		WithPhase("phase").Build()
 
 	suite.Equal("v1", pod.APIVersion)
 	suite.Equal("Pod", pod.Kind)
@@ -410,9 +439,9 @@ func (suite *Suite) TestNewNamespace() {
 
 func (suite *Suite) TestRandomPodSublice() {
 	pods := []v1.Pod{
-		NewPod("default", "foo", v1.PodRunning),
-		NewPod("testing", "bar", v1.PodRunning),
-		NewPod("test", "baz", v1.PodRunning),
+		NewPodBuilder("default", "foo").Build(),
+		NewPodBuilder("testing", "bar").Build(),
+		NewPodBuilder("test", "baz").Build(),
 	}
 
 	for _, tt := range []struct {


### PR DESCRIPTION
Adds ability to configure frequency for pod termination via annotation.

Closes #20 

Allows specifying a new command line flag, `--termination-frequency-annotation` which sets the annotation to look for and use to calculate the approximate frequency at which to terminate a given pod. Follows the examples given in #20, such as...
* `chaos.alpha.kubernetes.io/frequency=2/day` for "kill this twice per day"
* `chaos.alpha.kubernetes.io/frequency=10/hour` for "kill this ten times per hour"
* `chaos.alpha.kubernetes.io/frequency=1/week` for "kill this once a week"
* `chaos.alpha.kubernetes.io/frequency=0.5/day` for "kill this pod once every two days"

Pods without the annotation are assumed to always be candidates for termination. The `--max-kill` flag also still applies and will potentially limit how frequently a pod is terminated if it isn't high enough.