### PR TITLE
Update Helm chart, make RBAC optional, add Service

### DIFF
--- a/chart/chaoskube/templates/clusterrole.yaml
+++ b/chart/chaoskube/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -10,3 +11,4 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create"]
+{{- end }}

--- a/chart/chaoskube/templates/clusterrolebinding.yaml
+++ b/chart/chaoskube/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -11,3 +12,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "chaoskube.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/chaoskube/templates/deployment.yaml
+++ b/chart/chaoskube/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "chaoskube.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "chaoskube.serviceAccountName" . }}
       containers:
@@ -38,6 +41,14 @@ spec:
         {{- else }}
         - --{{ $key }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.chaoskube.metrics.enabled }}
+        - --metrics-address={{ .Values.chaoskube.metrics.port }}
+        {{- end }}
+        {{- if .Values.chaoskube.metrics.enabled }}
+        ports:
+          - name: metrics
+            containerPort: {{ .Values.chaoskube.metrics.port }}
         {{- end }}
         securityContext:
           {{- toYaml .Values.podSecurityContext | nindent 10 }}

--- a/chart/chaoskube/templates/service.yaml
+++ b/chart/chaoskube/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.chaoskube.metrics.enabled .Values.chaoskube.metrics.service.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chaoskube.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chaoskube.labels" . | nindent 4 }}
+
+spec:
+  type: {{ .Values.chaoskube.metrics.service.type }}
+
+  ports:
+    - port: {{ .Values.chaoskube.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: {{ include "chaoskube.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/chaoskube/templates/serviceaccount.yaml
+++ b/chart/chaoskube/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -10,3 +11,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/chart/chaoskube/values.yaml
+++ b/chart/chaoskube/values.yaml
@@ -12,6 +12,7 @@ image:
 # chaoskube is used to configure chaoskube
 chaoskube:
   env: {}
+
   args:
     # kill a pod every 10 minutes
     interval: "10m"
@@ -36,14 +37,29 @@ chaoskube:
     # terminate pods for real: this disables dry-run mode which is on by default
     no-dry-run: ""
 
+  metrics:
+    enabled: true
+    port: 8080
+
+    service:
+      create: true
+      type: ClusterIP
+
 # serviceAccount can be used to customize the service account which will be crated and used by chaoskube
 serviceAccount:
   create: true
   name: ""
   annotations: {}
 
+# rbac allows configuring the permissions for chaoskube
+rbac:
+  create: true
+
 # podAnnotations can be used to add additional annotations to the pod
 podAnnotations: {}
+
+# podAnnotations can be used to add additional labels to the pod
+podLabels: {}
 
 # podSecurityContext is used to customize the security context of the pod
 podSecurityContext:


### PR DESCRIPTION
I've got some additional changes to the Helm chart for Chaoskube.

Changes
* Made the `ClusterRole` and `ClusterRoleBinding` optional by setting `rbac.create` to `false`
* Added a `Service` which can be created and configured via `chaoskube.service`
* Added ability to configure additional pod labels via `podLabels`