### PR TITLE
Improve Helm experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ INFO[4804] terminating pod          name=nginx-701339712-51nt8 namespace=chaosku
 You can install `chaoskube` with [`Helm`](https://github.com/kubernetes/helm). Follow [Helm's Quickstart Guide](https://helm.sh/docs/intro/quickstart/) and then install the `chaoskube` chart.
 
 ```console
-$ helm install stable/chaoskube
+$ helm repo add chaoskube https://linki.github.io/chaoskube/
+$ helm install chaoskube chaoskube/chaoskube --atomic --namespace=chaoskube --create-namespace
 ```
 
 Refer to [chaoskube on kubeapps.com](https://kubeapps.com/charts/stable/chaoskube) to learn how to configure it and to find other useful Helm charts.

--- a/chart/chaoskube/Chart.yaml
+++ b/chart/chaoskube/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
     url: https://github.com/linki
   - name: Thomas Gosteli
     url: https://github.com/ghouscht
-version: 0.1.0
-appVersion: 0.21.0
+version: 0.2.0
+appVersion: 0.24.0

--- a/chart/chaoskube/README.md
+++ b/chart/chaoskube/README.md
@@ -1,14 +1,65 @@
 # chaoskube Helm Chart
+
 chaoskube periodically kills random pods in your Kubernetes cluster.
 
 ## Installation
 
-### Helm 3: install the chaoskube Helm Chart
-```
-helm repo add chaoskube https://chaoskube.github.io/chaoskube-kubernetes
-helm install ...
-
+```console
+$ helm repo add chaoskube https://linki.github.io/chaoskube/
+$ helm install chaoskube chaoskube/chaoskube --atomic --namespace=chaoskube --create-namespace
 ```
 
 ## Example Helm values
-...
+
+Basic configuration with `3` replicas and minimum resources assigned that will take out any pod it can find (including the other chaoskube pods):
+
+```yaml
+chaoskube:
+  args:
+    no-dry-run: ""
+replicaCount: 3
+resources:
+  limits:
+    cpu: 15m
+    memory: 32Mi
+  requests:
+    cpu: 15m
+    memory: 32Mi
+```
+
+More advance configuration that limits based on several factors like time, day of the week, and date:
+
+```yaml
+chaoskube:
+  args:
+    # kill a pod every 10 minutes
+    interval: "10m"
+    # only target pods in the test environment
+    labels: "environment=test"
+    # only consider pods with this annotation
+    annotations: "chaos.alpha.kubernetes.io/enabled=true"
+    # exclude all DaemonSet pods
+    kinds: "!DaemonSet"
+    # exclude all pods in the kube-system namespace
+    namespaces: "!kube-system"
+    # don't kill anything on weekends
+    excluded-weekdays: "Sat,Sun"
+    # don't kill anything during the night or at lunchtime
+    excluded-times-of-day: "22:00-08:00,11:00-13:00"
+    # don't kill anything as a joke or on christmas eve
+    excluded-days-of-year: "Apr1,Dec24"
+    # let's make sure we all agree on what the above times mean
+    timezone: "UTC"
+    # exclude all pods that haven't been running for at least one hour
+    #minimum-age: "1h"
+    # terminate pods for real: this disables dry-run mode which is on by default
+    no-dry-run: ""
+replicaCount: 3
+resources:
+  limits:
+    cpu: 15m
+    memory: 32Mi
+  requests:
+    cpu: 15m
+    memory: 32Mi
+```

--- a/chart/chaoskube/templates/deployment.yaml
+++ b/chart/chaoskube/templates/deployment.yaml
@@ -25,21 +25,25 @@ spec:
       serviceAccountName: {{ include "chaoskube.serviceAccountName" . }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.chaoskube.env }}
         env:
           {{ toYaml .Values.chaoskube.env | indent 8 }}
         {{- end }}
+        {{- with .Values.chaoskube.args }}
         args:
-        {{- range $key, $value := .Values.chaoskube.args }}
+        {{- range $key, $value := . }}
         {{- if $value }}
         - --{{ $key }}={{ $value }}
         {{- else }}
         - --{{ $key }}
         {{- end }}
         {{- end }}
+        {{- end }}
         securityContext:
           {{- toYaml .Values.podSecurityContext | nindent 10 }}
+        {{- with .Values.resources}}
         resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}

--- a/chart/chaoskube/values.yaml
+++ b/chart/chaoskube/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 # image specifies image location, tag and pullPolicy
 image:
-  repository: quay.io/linki/chaoskube
+  repository: ghcr.io/linki/chaoskube
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -12,29 +12,33 @@ image:
 # chaoskube is used to configure chaoskube
 chaoskube:
   env: {}
-  args:
+  args: {}
+    ######
+    # Example configuration, uncomment and adjust to your needs.
+    # Be sure to read: https://github.com/linki/chaoskube#flags
+    ######
     # kill a pod every 10 minutes
-    interval: "10m"
+    #interval: "10m"
     # only target pods in the test environment
-    labels: "environment=test"
+    #labels: "environment=test"
     # only consider pods with this annotation
-    annotations: "chaos.alpha.kubernetes.io/enabled=true"
+    #annotations: "chaos.alpha.kubernetes.io/enabled=true"
     # exclude all DaemonSet pods
-    kinds: "!DaemonSet"
+    #kinds: "!DaemonSet"
     # exclude all pods in the kube-system namespace
-    namespaces: "!kube-system"
+    #namespaces: "!kube-system"
     # don't kill anything on weekends
-    excluded-weekdays: "Sat,Sun"
+    #excluded-weekdays: "Sat,Sun"
     # don't kill anything during the night or at lunchtime
-    excluded-times-of-day: "22:00-08:00,11:00-13:00"
+    #excluded-times-of-day: "22:00-08:00,11:00-13:00"
     # don't kill anything as a joke or on christmas eve
-    excluded-days-of-year: "Apr1,Dec24"
+    #excluded-days-of-year: "Apr1,Dec24"
     # let's make sure we all agree on what the above times mean
-    timezone: "UTC"
+    #timezone: "UTC"
     # exclude all pods that haven't been running for at least one hour
-    minimum-age: "1h"
+    #minimum-age: "1h"
     # terminate pods for real: this disables dry-run mode which is on by default
-    no-dry-run: ""
+    #no-dry-run: ""
 
 # serviceAccount can be used to customize the service account which will be crated and used by chaoskube
 serviceAccount:


### PR DESCRIPTION
Since the deprecation of the `stable` Helm chart repository by Helm, chaoskube's chart is one of the charts I've been waiting for to be ported.

Initially, when that happened I didn't get it to work and didn't look too deep into it. Now that I'm building a home cluster it came up again,
and after looking into it properly there are a few things that came up:

- [X] The project's readme still lists the old `stable` Helm chart repository.
- [X] The chart's readme lists a non-existent (?) Helm chart repository
- [X] Has default values for arguments causing issues for some of those when empty
- [X] Missing `v` for the default tag
- [X] Using a non-amd64 OCI image on a raspberry pi was a bit of a search to find out and get working

P.S. This PR only aims to make it work out of the box again and contains some breaking changes causing the major version bump.