### PR TITLE
Fetch all git tags after shallow checkout and use the path context

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Get all git tags
+        run: git fetch --prune --unshallow --tags
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -49,6 +52,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
We're using the tags to determine the version within the Dockerfile. Let's see if this gets it back.

* The checkout action's checkout is ignored during the build-and-push phase unless `context: .` is used.
* The checkout action doesn't fetch any git tags. So add another action that fetches them.

