### PR TITLE
Let Dependabot update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
     interval: weekly
     time: "07:00"
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "07:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Let dependabot update github actions

as described in https://github.com/docker/build-push-action/blob/7c41daf2a5f378ed47e2c3e4da5152f52281f6a4/README.md#keep-up-to-date-with-github-dependabot