### PR TITLE
Use prefix for versioned docker tags

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -46,8 +46,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
 
       - name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
So, we'll get the previously used style, e.g. `ghcr.io/linki/chasokube:v0.23.0`.