### PR TITLE
Switch dependabot interval from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,18 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "07:00"
   open-pull-requests-limit: 10
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "07:00"
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "07:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
It currently creates a lot of pointless PRs each week because they are not reviewed/merged. Let's reduce the interval to monthly to reduce the noise.