### PR TITLE
feat: add envFrom ConfigMap to chart

### DIFF
--- a/chart/chaoskube/templates/deployment.yaml
+++ b/chart/chaoskube/templates/deployment.yaml
@@ -31,6 +31,13 @@ spec:
         env:
           {{ toYaml .Values.chaoskube.env | indent 8 }}
         {{- end }}
+        {{- if .Values.chaoskube.envFromConfigMapRefs }}
+        envFrom:
+          {{- range .Values.chaoskube.envFromConfigMapRefs }}
+          - configMapRef:
+              name: {{ . }}
+          {{- end }}
+        {{- end }}
         {{- with .Values.chaoskube.args }}
         args:
         {{- range $key, $value := . }}

--- a/chart/chaoskube/values.yaml
+++ b/chart/chaoskube/values.yaml
@@ -12,6 +12,8 @@ image:
 # chaoskube is used to configure chaoskube
 chaoskube:
   env: {}
+  envFromConfigMapRefs: []
+    # - 'configmap-a'
   args: {}
     ######
     # Example configuration, uncomment and adjust to your needs.


### PR DESCRIPTION
This adds the support to add `envFrom` with `configMapRef ` through Helm Values:

I wasn't able to use an array of maps with the current setup, like this:

```yaml
  chaoskube:
    env:
      - name: MY_VAR
        valueFrom:
          configMapKeyRef:
            name: chaoskube-cm1
            key: my-var
```

Results in: error converting YAML to JSON: yaml: line 39: did not find expected key

With this PR it will be possible to add the following: 

```yaml
  chaoskube:
    envFromConfigMapRefs:
       - chaoskube-cm1
       - chaoskube-cm2
```

What do you think, could this be merged? 