### PR TITLE
Add additionalLabels to values and deployment

### DIFF
--- a/chart/chaoskube/templates/deployment.yaml
+++ b/chart/chaoskube/templates/deployment.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chaoskube.labels" . | nindent 4 }}
+    {{- if .Values.additionalLabels }}
+    {{- range $key, $value := .Values.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   strategy:
     type: Recreate
@@ -21,6 +26,11 @@ spec:
       {{- end }}
       labels:
         {{- include "chaoskube.selectorLabels" . | nindent 8 }}
+        {{- if .Values.additionalLabels }}
+        {{- range $key, $value := .Values.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "chaoskube.serviceAccountName" . }}
       containers:

--- a/chart/chaoskube/values.yaml
+++ b/chart/chaoskube/values.yaml
@@ -51,6 +51,9 @@ serviceAccount:
 # podAnnotations can be used to add additional annotations to the pod
 podAnnotations: {}
 
+# additionalLabels can be used to add additional labels to the pod
+additionalLabels: {}
+
 # podSecurityContext is used to customize the security context of the pod
 podSecurityContext:
   runAsNonRoot: true


### PR DESCRIPTION
Hi Chaoskube Team,
we need to label all of our resources in our k8s clusters. Sometimes for human purpose, sometimes for technical purpose (f.e. NetworkPolicies).
I noticed that your helm chart does not yet offer the possibility to specify additional Labels that will be applied to the Deployment and the pods, so I created this PR.

Any feedback is appreciated.
Thanks!