### PR TITLE
chore(helm): upgrade chart to use appVersion 0.32.0

### DIFF
--- a/chart/chaoskube/Chart.yaml
+++ b/chart/chaoskube/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
     url: https://github.com/linki
   - name: Thomas Gosteli
     url: https://github.com/ghouscht
-version: 0.3.0
-appVersion: 0.27.0
+version: 0.4.0
+appVersion: 0.32.0


### PR DESCRIPTION
The app version in the helm chart is outdated. 
We would like to upgrade to the latest version of Chaoskube. 