### PR TITLE
feat: Set container port based on "metrics-address" argument

### DIFF
--- a/chart/chaoskube/Chart.yaml
+++ b/chart/chaoskube/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
     url: https://github.com/linki
   - name: Thomas Gosteli
     url: https://github.com/ghouscht
-version: 0.5.0
-appVersion: 0.38.0
+version: 0.6.0
+appVersion: 0.39.0

--- a/chart/chaoskube/templates/_helpers.tpl
+++ b/chart/chaoskube/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the port of the metrics endpoint, defaulting to 8080 if not set in args.
+We need to use some failure handling when default value '.Values.chaoskube.args' is used, otherwise we see
+errors like: wrong type for value; expected map[string]interface {}; got interface {}
+*/}}
+{{- define "chaoskube.metricsPort" -}}
+{{- $args := .Values.chaoskube.args -}}
+{{- $metricsAddr := index $args "metrics-address" -}}
+{{- $metricsPort := ($metricsAddr | toString | split ":")._1 -}}
+
+{{ printf "%s" ($metricsPort | default "8080") -}}
+{{- end -}}

--- a/chart/chaoskube/templates/deployment.yaml
+++ b/chart/chaoskube/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
         {{- end }}
         securityContext:
           {{- toYaml .Values.podSecurityContext | nindent 10 }}
+        ports:
+        - name: metrics
+          containerPort: {{ include "chaoskube.metricsPort" . }}
+          protocol: TCP
         {{- with .Values.resources}}
         resources:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
Most of the times, the containerPorts inside the podSpec seems a bit like decoration, but:

There are use cases which needs the containerPort set, like:
- Prometheus without Prometheus-Operator
- VictoriaMetrics without operator
- etc.

I tried to not introduce a new value and reuse what is already there today.